### PR TITLE
Remove the legacy config.py credential fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# Keys
-config.py
-
 # Generated artifacts
 optimization_results.csv
 walkforward_results.csv

--- a/README.md
+++ b/README.md
@@ -260,9 +260,8 @@ The proposer is **provider-agnostic** — choose with `--provider`:
 | `openai` | `uv sync --extra openai` | `gpt-4o` | `OPENAI_API_KEY` |
 | `ollama` (local) | none | `llama3.1` | none |
 
-Set the credential either in `config.py` (alongside your Alpaca keys — see
-`config_example.py`) or as the standard environment variable; the agent checks
-`config.py` first, then the environment. Ollama runs locally and needs no key.
+Set the credential in `.env` (alongside your Alpaca keys — see `.env.example`)
+or as the standard environment variable. Ollama runs locally and needs no key.
 
 ```bash
 uv run python main.py research --provider ollama --model llama3.1 \
@@ -329,7 +328,7 @@ make docs        # serve the Docusaurus site at http://localhost:3000
 
 ```bash
 make docker-build
-make docker-run            # paper live-trading; mounts your config.py
+make docker-run            # paper live-trading; mounts your .env
 ```
 
 ## Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ select = ["E", "F", "I", "W"]
 ignore = ["E501"]
 
 [tool.ruff.lint.isort]
-# Classify these as first-party explicitly. Otherwise import ordering depends on
-# whether `config.py` (gitignored) exists on disk — which differs between a local
-# checkout and CI, producing inconsistent I001 results.
-known-first-party = ["src", "config"]
+# Classify the application package as first-party so import ordering is stable
+# across a local checkout and CI.
+known-first-party = ["src"]

--- a/src/research/llm.py
+++ b/src/research/llm.py
@@ -50,7 +50,7 @@ class AnthropicClient(LLMClient):
     """Claude via the Anthropic SDK.
 
     The API key is resolved from ``ANTHROPIC_API_KEY`` via the standard settings
-    chain (environment / ``.env`` / legacy ``config.py``).
+    chain (environment / ``.env``).
     """
 
     def __init__(self, model: str = "claude-opus-4-8", client=None):
@@ -82,7 +82,7 @@ class OpenAIClient(LLMClient):
     """GPT models via the OpenAI SDK.
 
     The API key is resolved from ``OPENAI_API_KEY`` via the standard settings
-    chain (environment / ``.env`` / legacy ``config.py``).
+    chain (environment / ``.env``).
     """
 
     def __init__(self, model: str = "gpt-4o", client=None):
@@ -116,7 +116,7 @@ class OllamaClient(LLMClient):
     """Any local model served by Ollama, via its HTTP API (no SDK dependency).
 
     No API key. The server URL comes from ``OLLAMA_BASE_URL`` (environment /
-    ``.env`` / legacy ``config.py``), defaulting to ``http://localhost:11434``.
+    ``.env``), defaulting to ``http://localhost:11434``.
     """
 
     def __init__(self, model: str = "llama3.1", base_url: Optional[str] = None, timeout: float = 120.0):

--- a/src/settings.py
+++ b/src/settings.py
@@ -7,9 +7,6 @@ Every setting is resolved in the same predictable order:
 2. **A ``.env`` file** in the project root, loaded into the environment on first
    use. No dependency: a tiny built-in parser handles ``KEY=value`` lines, and
    real environment variables already set always win (standard dotenv behaviour).
-3. **A legacy ``config.py`` module**, if present - the pre-``.env`` mechanism.
-   Still honoured so existing checkouts keep working, but ``.env`` is the
-   recommended path now (see ``.env.example``).
 
 Alpaca credentials are required for any command that touches the market
 (``scan``/``backtest``/``live``/``optimize``/...); the offline ``demo`` command
@@ -65,31 +62,14 @@ def _load_dotenv_once() -> None:
         os.environ.setdefault(key.strip(), value.strip().strip('"').strip("'"))
 
 
-def _legacy_config():
-    """Return the legacy ``config.py`` module, or ``None`` if it isn't present."""
-    try:
-        import config  # gitignored; the pre-.env credential file
-    except ModuleNotFoundError:
-        return None
-    return config
-
-
 def get_credential(name: str, default: Optional[str] = None) -> Optional[str]:
-    """Resolve a single named setting: env / ``.env`` first, then ``config.py``.
+    """Resolve a single named setting from the environment (or ``.env``).
 
     Used for LLM provider keys (``ANTHROPIC_API_KEY`` ...) and the Alpaca keys
     alike, so every credential follows one rule.
     """
     _load_dotenv_once()
-    value = os.environ.get(name)
-    if value:
-        return value
-    legacy = _legacy_config()
-    if legacy is not None:
-        value = getattr(legacy, name, None)
-        if value:
-            return value
-    return default
+    return os.environ.get(name) or default
 
 
 def _parse_bool(value: object, default: bool = True) -> bool:
@@ -105,9 +85,6 @@ def _resolve_paper_trade() -> bool:
     _load_dotenv_once()
     if "PAPER_TRADE" in os.environ:
         return _parse_bool(os.environ["PAPER_TRADE"])
-    legacy = _legacy_config()
-    if legacy is not None and hasattr(legacy, "PAPER_TRADE"):
-        return _parse_bool(legacy.PAPER_TRADE)
     return True
 
 
@@ -140,7 +117,7 @@ def load_settings() -> Settings:
             + ", ".join(missing)
             + ".\nCopy .env.example to .env and add your Alpaca paper-trading keys "
             "(free at https://app.alpaca.markets/ -> Paper Account -> API Keys).\n"
-            "Environment variables and a legacy config.py are also honoured. "
+            "Environment variables are honoured too. "
             "No keys needed to explore? Run `make demo`."
         )
     return Settings(alpaca_key=key, alpaca_secret=secret, paper_trade=_resolve_paper_trade())

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,6 @@
-"""Tests for credential resolution (env / .env / legacy config.py) + validation."""
+"""Tests for credential resolution (env / .env) + validation."""
 
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -11,10 +10,9 @@ from src.settings import SettingsError, load_settings
 
 @pytest.fixture(autouse=True)
 def _isolate(monkeypatch):
-    """Run each test with no .env file, no legacy config, and a clean environment."""
+    """Run each test with no .env file and a clean environment."""
     monkeypatch.setattr(settings, "_dotenv_loaded", False)
     monkeypatch.setattr(settings, "ENV_PATH", Path("/nonexistent/.env"))
-    monkeypatch.setattr(settings, "_legacy_config", lambda: None)
     for key in ("APCA_API_KEY_ID", "APCA_API_SECRET_KEY", "PAPER_TRADE", "ANTHROPIC_API_KEY"):
         monkeypatch.delenv(key, raising=False)
 
@@ -47,24 +45,6 @@ def test_placeholder_values_count_as_missing(monkeypatch):
     monkeypatch.setenv("APCA_API_SECRET_KEY", "<APCA_API_SECRET_KEY>")
     with pytest.raises(SettingsError):
         load_settings()
-
-
-def test_legacy_config_is_a_fallback(monkeypatch):
-    legacy = SimpleNamespace(APCA_API_KEY_ID="legacyk", APCA_API_SECRET_KEY="legacys", PAPER_TRADE=True)
-    monkeypatch.setattr(settings, "_legacy_config", lambda: legacy)
-
-    s = load_settings()
-    assert s.alpaca_key == "legacyk"
-    assert s.paper_trade is True
-
-
-def test_env_wins_over_legacy(monkeypatch):
-    legacy = SimpleNamespace(APCA_API_KEY_ID="legacyk", APCA_API_SECRET_KEY="legacys")
-    monkeypatch.setattr(settings, "_legacy_config", lambda: legacy)
-    monkeypatch.setenv("APCA_API_KEY_ID", "envk")
-    monkeypatch.setenv("APCA_API_SECRET_KEY", "envs")
-
-    assert load_settings().alpaca_key == "envk"
 
 
 def test_get_credential_falls_back_to_default():

--- a/website/docs/engineering/research-agent.md
+++ b/website/docs/engineering/research-agent.md
@@ -71,7 +71,7 @@ The loop and guardrails are proposer-agnostic. `LLMProposer` drives any
 
 `build_proposer(provider, model)` / `build_llm_client(provider, model)` pick the
 backend. Credentials resolve through the shared settings chain — environment /
-`.env`, then a legacy `config.py` — via `src.settings.get_credential`
+`.env` — via `src.settings.get_credential`
 (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`; `OLLAMA_BASE_URL` for the local server).
 `FixedProposer` replays a fixed list for deterministic offline tests.
 

--- a/website/docs/engineering/testing.md
+++ b/website/docs/engineering/testing.md
@@ -28,7 +28,7 @@ uv run --extra dev pytest tests/test_live_trader.py::test_hold_is_noop  # one te
 
 Notes:
 
-- **No setup needed** — no `config.py`, keys, or network. Tests use the fakes below.
+- **No setup needed** — no keys or network. Tests use the fakes below.
 - The **OR-Tools** portfolio tests `skip` automatically if that optional dependency
   isn't installed; everything else runs with just the `dev` extra.
 - CI runs the same command on every push/PR, alongside `ruff check` and

--- a/website/docs/usage/agents.md
+++ b/website/docs/usage/agents.md
@@ -80,8 +80,8 @@ uv run python main.py research --provider openai --model gpt-4o ...
 ### Setting credentials
 
 You can provide a key **either** in `.env` **or** as the standard environment
-variable — they resolve through the same chain (`environment` → `.env` → legacy
-`config.py`), so the SDK defaults keep working and you don't have to duplicate keys.
+variable — they resolve through the same chain (`environment` → `.env`), so the
+SDK defaults keep working and you don't have to duplicate keys.
 
 `.env` (alongside your Alpaca keys — see `.env.example`):
 

--- a/website/docs/usage/configuration.md
+++ b/website/docs/usage/configuration.md
@@ -36,8 +36,6 @@ order, so there's never any ambiguity:
 1. **Environment variables** — the standard, 12-factor way (`export APCA_API_KEY_ID=…`).
 2. **`.env`** in the project root — loaded automatically; real environment
    variables already set always win.
-3. **A legacy `config.py`** module, if present — the pre-`.env` mechanism, still
-   honoured so older checkouts keep working. New setups should use `.env`.
 
 The same chain resolves the optional LLM provider keys for the research agent
 (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `OLLAMA_BASE_URL`) — set them in `.env`


### PR DESCRIPTION
Credentials now resolve solely from the environment (and a .env file). The pre-.env config.py module is dropped: settings.get_credential and paper-trade resolution lose their config.py branch, and the docs, .gitignore, isort config, and tests are updated to match. No backward-compatibility shim is kept.