### PR TITLE
Feat/lazy compute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,6 @@ website/.docusaurus/
 # Mongo Data
 /data/db
 
-__init__.py
-
 # Below is a standard to gitignore file for Python
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ doing its job.
 | `live` | Scan → warm up indicators → stream bars → place paper/live orders |
 | `optimize` | Search strategy parameters by backtest objective (grid / random / Bayesian) |
 | `allocate` | Weight a portfolio: scalar-score sizing (OR-Tools), or `--objective utility` for mean-variance construction from alpha + Σ |
-| `alphas` | Rank a universe by continuous alpha — a comparable, annualized residual-return forecast per name; `--combine` blends several signals (read-only) |
+| `alphas` | Rank a universe by continuous alpha — a comparable, annualized residual-return forecast per name; `--combine` blends several signals, `--neutralize-factors` regresses out the risk model's factor exposures (read-only) |
 | `risk` | Estimate the universe covariance Σ (Ledoit–Wolf shrinkage) and summarize its risk structure (read-only) |
 | `info` | Information report: measure IC, breadth, and predicted-vs-realized IR — skill vs luck (read-only) |
 | `horizon` | Measure alpha decay / half-life; recommend rebalance cadence + current/lagged blend (read-only) |

--- a/main.py
+++ b/main.py
@@ -177,24 +177,47 @@ def _allocate_utility(args) -> None:
         min_weight=args.min_weight,
         max_names=args.max_names,
         benchmark=args.benchmark,
+        neutralize_factors=args.neutralize_factors,
         capital=args.capital,
+        holding_period_years=args.holding_period,
+        cost_aware=not args.gross_objective,
     )
     if not result["feasible"]:
         print(f"Infeasible: {result.get('binding_constraint') or result.get('note')}")
         return
 
     d = result["diagnostics"]
-    print(f"\nPortfolio for '{args.strategy}' as of {args.as_of:%Y-%m-%d} (target TE {args.target_te:.0%})")
+    mode = "cost-aware" if d.get("cost_aware") else "gross (cost-blind)"
+    print(
+        f"\nPortfolio for '{args.strategy}' as of {args.as_of:%Y-%m-%d} "
+        f"(target TE {args.target_te:.0%}, {mode})"
+    )
     print(
         f"  IR* {d['ir_star']:.2f}  predicted TE {d['predicted_tracking_error']:.1%}  "
         f"predicted IR {d['predicted_ir']:.2f}  transfer coef {d['transfer_coefficient']:.2f}  "
         f"turnover {d['turnover']:.1%}"
     )
-    if "capacity_capital" in d:
+    if "round_trip_cost" in d:
+        # Headline: the conservative round-trip haircut (enter + exit, amortised) - the
+        # same cost model as capacity, so the two agree.
         print(
-            f"  cost drag {d['cost_drag']:.2%}/yr  capacity ≈ ${d['capacity_capital']:,.0f} "
-            f"(where √-impact erases the alpha)"
+            f"  net active return {d['expected_active_return_net']:.2%}/yr (round-trip)  "
+            f"= gross {d['expected_active_return']:.2%} − round-trip cost {d['round_trip_cost']:.2%}"
         )
+        # Detail: the one-way cost of this rebalance's turnover (prior reporting).
+        if d.get("cost_aware"):
+            print(
+                f"    this rebalance: turnover cost {d['cost_drag']:.2%}/yr one-way "
+                f"(linear {d['linear_cost']:.2%} + √-impact {d['impact_cost']:.2%}); "
+                f"one-way net {d['expected_active_return_net_oneway']:.2%}"
+            )
+        else:
+            print(
+                f"    this rebalance: turnover cost {d['cost_drag']:.2%}/yr one-way; "
+                f"one-way net {d['expected_active_return_net_oneway']:.2%}"
+            )
+    if "capacity_capital" in d:
+        print(f"  capacity ≈ ${d['capacity_capital']:,.0f} (where √-impact erases the alpha)")
     print(f"\n{'SYMBOL':10}{'WEIGHT':>8}" + (f"{'DOLLARS':>14}{'SHARES':>10}" if result["holdings"] else ""))
     if result["holdings"]:
         for h in result["holdings"]:
@@ -442,6 +465,7 @@ def cmd_alphas(args) -> None:
                 as_of=args.as_of,
                 benchmark=args.benchmark,
                 neutralize=args.neutralize,
+                neutralize_factors=args.neutralize_factors,
                 lookback_days=args.lookback_days,
             ),
             args,
@@ -458,6 +482,7 @@ def cmd_alphas(args) -> None:
         ic=args.ic,
         benchmark=args.benchmark,
         neutralize=args.neutralize,
+        neutralize_factors=args.neutralize_factors,
         lookback_days=args.lookback_days,
     )
 
@@ -467,6 +492,7 @@ def cmd_alphas(args) -> None:
         "scanner": f"scanner '{args.scanner}' strength",
     }[args.source]
     print(f"\nAlphas from {src_desc} as of {args.as_of:%Y-%m-%d} (IC={args.ic}, benchmark={args.benchmark})")
+    _print_neutralization(result)
     if not result["benchmark_available"]:
         print("  ! benchmark unavailable — residual vol falls back to total volatility")
     if result["low_confidence"]:
@@ -483,6 +509,25 @@ def cmd_alphas(args) -> None:
         )
 
 
+def _print_neutralization(result) -> None:
+    """One honest line about what the alphas were actually regressed against.
+
+    Reports what was *applied* (from the refinement's meta), not what was requested —
+    and warns when a requested factor exposure was unavailable, so "factor-neutral"
+    is never claimed for un-neutralized output.
+    """
+    requested = result.get("neutralize_factors") or []
+    applied = result.get("neutralized_against") or []
+    if applied:
+        print(f"  neutralized against: {', '.join(applied)}")
+    missing = [f for f in requested if f not in applied]
+    if missing:
+        print(
+            f"  ! requested factor(s) NOT neutralized (exposures unavailable — "
+            f"insufficient history?): {', '.join(missing)}"
+        )
+
+
 def _print_combined_alphas(result, args) -> None:
     """Print the multi-signal combination: per-signal weights/ICs + the combined alphas."""
     if not result.get("universe_size"):
@@ -490,6 +535,7 @@ def _print_combined_alphas(result, args) -> None:
         return
 
     print(f"\nCombined alpha from {', '.join(result['signals'])} as of {args.as_of:%Y-%m-%d}")
+    _print_neutralization(result)
     print(f"  measured over {result['n_periods']} rebalances  |  combined IC {result['combined_ic']:.4f}")
     print(f"\n{'SIGNAL':16}{'IC':>9}{'SHRUNK':>9}{'WEIGHT':>9}")
     for sig in result["signals"]:
@@ -567,6 +613,7 @@ def cmd_info(args) -> None:
         source=args.source,
         scanner=args.scanner,
         benchmark=args.benchmark,
+        neutralize_factors=args.neutralize_factors,
         horizon=args.horizon,
         n_trials=args.n_trials,
     )
@@ -618,6 +665,7 @@ def cmd_horizon(args) -> None:
         source=args.source,
         scanner=args.scanner,
         benchmark=args.benchmark,
+        neutralize_factors=args.neutralize_factors,
         max_lag=args.max_lag,
         timeframe=args.timeframe,
     )
@@ -790,6 +838,37 @@ def _symbols(value: str) -> List[str]:
     return [s.strip().upper() for s in value.split(",") if s.strip()]
 
 
+#: The bare-flag default for --neutralize-factors: the risk-control factors.
+#: Momentum is deliberately excluded — a momentum tilt is a return bet the alphas
+#: may intend; regress it out explicitly if that's the goal.
+DEFAULT_NEUTRAL_FACTORS = ["market", "volatility", "size"]
+
+
+def _factors(value: str) -> List[str]:
+    from src.risk.exposures import FACTOR_NAMES
+
+    factors = [s.strip().lower() for s in value.split(",") if s.strip()]
+    unknown = [f for f in factors if f not in FACTOR_NAMES]
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            f"unknown factor(s) {', '.join(unknown)}; available: {', '.join(FACTOR_NAMES)}"
+        )
+    return factors
+
+
+def _add_neutralize_factors_flag(parser, note: str = "") -> None:
+    parser.add_argument(
+        "--neutralize-factors",
+        dest="neutralize_factors",
+        type=_factors,
+        nargs="?",
+        const=DEFAULT_NEUTRAL_FACTORS,
+        default=[],
+        help="Factor-neutral alphas: regress out these risk-model exposures "
+        f"(comma-separated; bare flag = {','.join(DEFAULT_NEUTRAL_FACTORS)} — momentum kept){note}",
+    )
+
+
 def _date(value: str) -> datetime:
     return datetime.strptime(value, "%Y-%m-%d")
 
@@ -903,6 +982,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Dust floor: min weight if held (utility)",
     )
     alloc.add_argument("--benchmark", default="SPY", help="Benchmark for residual vol / beta (utility)")
+    _add_neutralize_factors_flag(alloc, note=" (utility)")
+    alloc.add_argument(
+        "--gross-objective",
+        dest="gross_objective",
+        action="store_true",
+        help="Cost-blind solve (utility): drop 007's cost from the objective, report it ex-post only. "
+        "Default is cost-aware (name-specific turnover + √-impact in the objective).",
+    )
+    alloc.add_argument(
+        "--holding-period",
+        dest="holding_period",
+        type=float,
+        default=1.0 / 12.0,
+        help="Expected holding period in years, to annualise the in-objective cost (utility; default 1/12)",
+    )
     alloc.set_defaults(func=cmd_allocate)
 
     opt = subparsers.add_parser(
@@ -1001,6 +1095,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Make alphas beta-neutral (regress out benchmark beta)",
     )
+    _add_neutralize_factors_flag(alphas)
     alphas.add_argument("--lookback-days", dest="lookback_days", type=int, default=180)
     alphas.set_defaults(func=cmd_alphas)
 
@@ -1025,6 +1120,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Configs tried (for multiple-testing inflation)",
     )
+    _add_neutralize_factors_flag(info, note="; measure the alpha you deploy")
     info.set_defaults(func=cmd_info)
 
     hz = subparsers.add_parser(
@@ -1042,6 +1138,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-lag", dest="max_lag", type=int, default=10, help="Largest lag (periods) to measure"
     )
     hz.add_argument("--timeframe", default="1Day")
+    _add_neutralize_factors_flag(hz, note="; measure the alpha you deploy")
     hz.set_defaults(func=cmd_horizon)
 
     risk = subparsers.add_parser(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,16 @@ openai = ["openai>=1.40"]
 # (Ollama needs no dependency - the research agent talks to its local HTTP API.)
 # Render the demo artifact (equity curve + walk-forward verdict) to an image.
 viz = ["matplotlib>=3.8"]
-# Out-of-core columnar storage: an Arrow/Parquet bar store behind the scan() seam,
-# so the data tier scales without touching the layers above. Opt-in; pure wheels.
-store = ["pyarrow>=14"]
-dev = ["pytest>=8.0", "ruff>=0.6", "scikit-learn>=1.4", "ortools>=9.8", "matplotlib>=3.8", "pyarrow>=14"]
+# Out-of-core columnar storage + lazy compute: an Arrow/Parquet bar store behind the
+# scan() seam (011), plus lazy/streaming panel-wide compute over it (015 — Polars for
+# dataframe transforms, DuckDB for set-based queries). Opt-in; all pure wheels, so the
+# no-compiler promise holds. polars>=1.25: the streaming terminal uses
+# collect(engine="streaming"), which replaced the streaming= kwarg at 1.25.
+store = ["pyarrow>=14", "polars>=1.25", "duckdb>=1.0"]
+dev = [
+    "pytest>=8.0", "ruff>=0.6", "scikit-learn>=1.4", "ortools>=9.8", "matplotlib>=3.8",
+    "pyarrow>=14", "polars>=1.25", "duckdb>=1.0",
+]
 
 [tool.uv]
 # This is an application, not a library: install dependencies only, don't build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tradeflow"
-version = "0.2.0"
+version = "0.3.0"
 description = "A simple, layered, broker-agnostic algorithmic trading engine (Alpaca adapter included; backtest + live)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/alphas/__init__.py
+++ b/src/alphas/__init__.py
@@ -1,0 +1,53 @@
+"""Continuous alphas: turn a score column into a comparable residual-return forecast.
+
+The central active-management move: convert a raw, arbitrary-scale signal into an
+*alpha* - a forecast of residual return in annualised-return units, the same for
+every name - so views can be pooled, ranked, and sized by a mean-variance
+optimiser. Research-clock only: alphas forecast, they never trade.
+
+The refinement runs over a :class:`~src.data.panel.FeaturePanel`: a scorer
+(:mod:`src.alphas.scorers`) fills the ``score`` column, :func:`refine_alpha` adds
+``z`` and ``alpha`` via the identity ``alpha = sigma * IC * z``, and
+:func:`panel_to_alphas` exports the ranked :class:`Alpha` rows.
+"""
+
+from src.alphas.base import (
+    DEFAULT_IC,
+    DEFAULT_MIN_UNIVERSE,
+    Alpha,
+    AlphaContext,
+    panel_to_alphas,
+    refine_alpha,
+)
+from src.alphas.combine import (
+    SignalMeasurement,
+    combination_weights,
+    combine_scores,
+    combined_ic,
+    combined_score,
+    effective_ic,
+    measure_signals,
+    shrink_ic,
+)
+from src.alphas.scorers import Scorer, scanner_scorer, signal_scorer, strategy_scorer
+
+__all__ = [
+    "Alpha",
+    "AlphaContext",
+    "refine_alpha",
+    "panel_to_alphas",
+    "Scorer",
+    "strategy_scorer",
+    "signal_scorer",
+    "scanner_scorer",
+    "DEFAULT_IC",
+    "DEFAULT_MIN_UNIVERSE",
+    "SignalMeasurement",
+    "measure_signals",
+    "combined_score",
+    "combination_weights",
+    "combined_ic",
+    "effective_ic",
+    "shrink_ic",
+    "combine_scores",
+]

--- a/src/alphas/base.py
+++ b/src/alphas/base.py
@@ -22,6 +22,7 @@ from typing import List
 import pandas as pd
 
 from src.alphas import refine
+from src.data.features import EXPOSURE_PREFIX
 from src.data.panel import FeaturePanel
 
 #: Conservative default information coefficient. The absolute scale of alphas is
@@ -53,6 +54,12 @@ class AlphaContext:
     ic: float = DEFAULT_IC
     default_residual_vol: float = 0.20  # fallback when a name has no risk estimate
     neutralize: bool = False  # regress out the benchmark-beta exposure
+    #: Risk-model factors to regress out (``exp_<name>`` panel columns, written by
+    #: :func:`src.data.features.add_factor_exposure_features`). ``"market"`` here
+    #: supersedes the plain-beta ``neutralize`` (same exposure, standardized).
+    #: Momentum is deliberately absent from the usual set — a momentum tilt is a
+    #: return bet the alphas may intend; market/volatility/size are risk-control.
+    neutralize_factors: tuple = ()
     winsorize_limits: tuple = (0.025, 0.975)
     alpha_cap_std: float = 3.0
     min_universe: int = DEFAULT_MIN_UNIVERSE
@@ -66,7 +73,9 @@ def refine_alpha(
     """Refine a panel's ``score`` column into ``z`` and ``alpha`` columns.
 
     Cross-sectional at this one rebalance: winsorize, z-score, optionally neutralize
-    against the ``beta`` exposure, scale by ``sigma * IC``, then cap. On a thin
+    against the ``beta`` exposure and/or the risk-model factor block
+    (``context.neutralize_factors`` reading ``exp_<factor>`` columns), scale by
+    ``sigma * IC``, then cap. On a thin
     universe (``< context.min_universe`` scored names) winsorize and the unit-std
     scaling are skipped in favour of demean-only, and ``panel.meta['low_confidence']``
     is set. Reads ``residual_vol`` for ``sigma`` (falling back to the context default).
@@ -90,10 +99,33 @@ def refine_alpha(
     else:
         z = refine.zscore(refine.winsorize(s, *context.winsorize_limits))
 
-    # 3. Optional benchmark-beta neutralisation (regress z on the beta exposure).
-    if context.neutralize and not thin and panel.has("beta"):
-        exposures = panel.get("beta").reindex(z.index).to_frame("beta")
-        z = refine.neutralize(z, exposures)
+    # 3. Optional neutralisation: benchmark beta and/or risk-model factor exposures
+    #    (one regression on the union, so the residual is orthogonal to all of it).
+    #    A factor column is used only if it actually varies across covered names —
+    #    an absent, all-NaN, or constant column must degrade to beta neutralisation,
+    #    never silently to *no* neutralisation. Names missing a factor value get the
+    #    cross-sectional mean (0 — exposures are standardized), which keeps them in
+    #    the regression instead of stripping their beta neutralisation too.
+    if not thin:
+        columns = {}
+        imputed = 0
+        for factor in context.neutralize_factors:
+            col = f"{EXPOSURE_PREFIX}{factor}"
+            if not panel.has(col):
+                continue
+            series = panel.get(col).reindex(z.index)
+            if series.notna().sum() >= 2 and series.std(ddof=0) > 0:
+                imputed += int(series.isna().sum())
+                columns[col] = series.fillna(0.0)
+        market_col = f"{EXPOSURE_PREFIX}market"
+        if context.neutralize and panel.has("beta") and market_col not in columns:
+            columns["beta"] = panel.get("beta")
+        if columns:
+            z = refine.neutralize(z, pd.DataFrame(columns).reindex(z.index))
+        panel.meta["neutralized_against"] = [
+            c[len(EXPOSURE_PREFIX) :] if c.startswith(EXPOSURE_PREFIX) else c for c in columns
+        ]
+        panel.meta["neutralize_imputed"] = imputed
 
     # 4. Scale to a residual-return forecast via alpha_i = sigma_i * IC * z_i.
     if panel.has("residual_vol"):

--- a/src/costs/__init__.py
+++ b/src/costs/__init__.py
@@ -1,0 +1,11 @@
+"""Transaction costs: price the cost of trading so research metrics are net, not gross.
+
+A parametric model (commission + half-spread + square-root market impact) charged on
+every simulated fill, and an alpha haircut + linear turnover term for the optimiser.
+Research-clock only - the live path gets real fills from the broker.
+"""
+
+from src.costs.base import CostModel, Trade, TradeCost
+from src.costs.parametric import ParametricCostModel
+
+__all__ = ["CostModel", "Trade", "TradeCost", "ParametricCostModel"]

--- a/src/costs/base.py
+++ b/src/costs/base.py
@@ -65,6 +65,26 @@ class CostModel(ABC):
         notional = trade.notional
         return self.cost(trade).total / notional if notional > 0 else 0.0
 
+    def turnover_cost_rate(self, spread: float = None) -> float:
+        """Linear (size-independent) one-way cost per unit of traded notional.
+
+        The size-independent part of a trade's cost — the optimiser's L1 turnover
+        coefficient (Spec 016). A model with no linear cost returns 0 (the default);
+        :class:`~src.costs.parametric.ParametricCostModel` returns commission + s/2.
+        """
+        return 0.0
+
+    def impact_coefficient(self, daily_vol: float, adv_dollar: float, capital: float) -> float:
+        """√-impact coefficient ``k`` for the optimiser's ``Σ kᵢ·|Δwᵢ|^{3/2}`` term.
+
+        The realistic square-root impact is convex in size but not quadratic, so it
+        enters Spec 008's objective as a conic term rather than the risk quadratic.
+        ``k`` is *per unit of capital, per rebalance*: the impact cost as a fraction of
+        capital of trading ``|Δwᵢ|`` (a fraction of the ``capital`` book) is
+        ``k·|Δwᵢ|^{3/2}``. A model with no impact returns 0 (the default).
+        """
+        return 0.0
+
     def carry_cost(self, notional: float, is_short: bool, holding_years: float) -> float:
         """Financing cost of *holding* a position (borrow on shorts). Default: none."""
         return 0.0

--- a/src/costs/parametric.py
+++ b/src/costs/parametric.py
@@ -85,3 +85,20 @@ class ParametricCostModel(CostModel):
         """
         s = self.default_spread if spread is None else spread
         return self.commission_rate + s / 2.0
+
+    def impact_coefficient(self, daily_vol: float, adv_dollar: float, capital: float) -> float:
+        """√-impact coefficient ``k`` (per unit capital) for the optimiser's conic term.
+
+        The √-law impact rate is ``η·σ·√(participation)`` with ``participation =
+        |q|/ADV``. Trading ``|Δw|`` of a ``capital``-dollar book is ``q = |Δw|·capital/p``
+        shares, so ``participation = |Δw|·capital / (p·ADV) = |Δw|·capital / ADV$``. The
+        impact cost as a *fraction of capital* is then ``η·σ·√(capital/ADV$)·|Δw|^{3/2}``,
+        so ``k = η·σ·√(capital/ADV$)``. Zero when ADV is unavailable (mirrors
+        :meth:`cost`, which charges no impact without volume) or in linear-impact mode
+        (that fallback is quadratic-in-size, not conic, and isn't fed to the optimiser).
+        """
+        # `not (x > 0)` (rather than `x <= 0`) also rejects NaN, so a bad ADV/vol input
+        # drops the impact term instead of poisoning the solve with a NaN coefficient.
+        if self.linear_impact or not (adv_dollar > 0) or not (capital > 0) or not (daily_vol > 0):
+            return 0.0
+        return self.impact_eta * daily_vol * math.sqrt(capital / adv_dollar)

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,28 @@
+"""Cross-sectional data substrate: scan bars point-in-time, assemble a feature panel.
+
+The single place data is gathered for cross-sectional research (alphas, risk,
+portfolio construction, information analysis): :func:`~src.data.scan.BarSource`
+scans a universe as of a timestamp (leakage-safe), and a :class:`~src.data.panel.FeaturePanel`
+holds every name's features in one table that producers fill and consumers read.
+"""
+
+from src.data.features import Scorer, add_risk_features, add_score_feature
+from src.data.panel import FeaturePanel
+from src.data.scan import BarSource, ClientBarSource, slice_to_as_of
+from src.data.store import BAR_COLUMNS, ParquetBarStore
+
+# Lazy out-of-core compute (spec 015) lives in src.data.compute / src.data.edges and
+# is imported on demand — both need the optional ``store`` extra (polars/duckdb), so
+# they are intentionally not pulled into the base-install import path here.
+
+__all__ = [
+    "BarSource",
+    "ClientBarSource",
+    "slice_to_as_of",
+    "FeaturePanel",
+    "Scorer",
+    "add_risk_features",
+    "add_score_feature",
+    "ParquetBarStore",
+    "BAR_COLUMNS",
+]

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -6,7 +6,7 @@ scans a universe as of a timestamp (leakage-safe), and a :class:`~src.data.panel
 holds every name's features in one table that producers fill and consumers read.
 """
 
-from src.data.features import Scorer, add_risk_features, add_score_feature
+from src.data.features import Scorer, add_factor_exposure_features, add_risk_features, add_score_feature
 from src.data.panel import FeaturePanel
 from src.data.scan import BarSource, ClientBarSource, slice_to_as_of
 from src.data.store import BAR_COLUMNS, ParquetBarStore
@@ -21,6 +21,7 @@ __all__ = [
     "slice_to_as_of",
     "FeaturePanel",
     "Scorer",
+    "add_factor_exposure_features",
     "add_risk_features",
     "add_score_feature",
     "ParquetBarStore",

--- a/src/data/compute.py
+++ b/src/data/compute.py
@@ -1,0 +1,332 @@
+"""Lazy, out-of-core compute over the bar panel (spec 015 — Polars · DuckDB).
+
+Spec 011 delivered the *storage* half of out-of-core (a Parquet/Arrow ``BarSource``
+behind ``scan()``). This module is the *compute* half: the hot, panel-wide
+operations expressed as a **lazy** plan, rather than eagerly materialising a ``T×N``
+pandas panel into RAM.
+
+Two engines, sharing Arrow so it isn't either/or:
+
+- **Polars ``LazyFrame``** for dataframe-style transforms — rolling-window indicators
+  become window expressions ``.over("symbol", order_by="ts")``, and the
+  cross-sectional z-score / winsorize / rank become ``.over("ts")`` expressions.
+  Nothing materialises until a terminal :func:`~src.data.edges.collect_streaming`.
+- **DuckDB SQL** (:func:`sql_query`) for set-based work over the Parquet store
+  (aggregations, joins) — its out-of-core engine streams the scan too.
+
+Three disciplines the spec calls out and this module keeps:
+
+1. **Pushdown survives the plan.** A lazy scan reads only the columns/row-ranges it
+   needs and the ``as_of`` predicate is pushed into the Parquet reader — never a
+   post-materialise filter (see :meth:`ParquetBarStore.scan_lazy`).
+2. **Determinism under multithreading.** Polars/DuckDB parallelise; float reduction
+   order can vary. The cross-sectional reductions here are order-invariant
+   (mean/std/quantile), and :data:`CANONICAL_SORT` pins a stable output order so
+   repeated runs are byte-identical.
+3. **The pandas edge stays narrow.** Every crossing back to pandas routes through
+   :mod:`src.data.edges`; this module returns Polars frames / numpy, never pandas.
+
+**A note on what is genuinely bounded-memory.** The leaf Parquet scan (with its
+pushed-down predicate/projection) streams, and :func:`streaming_covariance` is bounded
+by the universe size, not by history length. But in the current Polars engine a
+``.over(...)`` window groupby and a top-level :func:`sort_canonical` are *buffering*
+operators — they materialise their input — so a pipeline that ends on a cross-sectional
+``over("ts")`` plus a canonical sort has peak memory ~ the panel it sorts, not O(chunk).
+The honest out-of-core wins today are the streaming scan, the as-of pushdown, and the
+streaming covariance accumulator; the set-based DuckDB path (which can spill) is the
+route to a genuinely bounded cross-sectional reduction. The window *math* is correct
+either way; only the memory profile of the buffering stages is not O(1) in history.
+
+The legacy pandas implementations (:mod:`src.indicators.indicators`,
+:mod:`src.alphas.refine`, :mod:`src.risk.sample`) are kept as the equivalence
+oracle — the tests prove these lazy ports match them within tolerance.
+
+Requires the ``store`` extra (``polars``; ``duckdb`` for :func:`sql_query`).
+"""
+
+from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import polars as pl
+
+#: Column names of the long-format bar panel (matches the Parquet store schema).
+TS = "ts"
+SYMBOL = "symbol"
+
+#: Canonical output ordering. Pinning an explicit sort makes a multithreaded collect
+#: byte-identical run to run (hidden factor 2 — determinism).
+CANONICAL_SORT = [TS, SYMBOL]
+
+
+def sort_canonical(lf: "pl.LazyFrame") -> "pl.LazyFrame":
+    """Pin the deterministic ``(ts, symbol)`` output order on a lazy plan."""
+    return lf.sort(CANONICAL_SORT)
+
+
+# --------------------------------------------------------------------------- #
+# Time-series indicators — Polars window expressions, partitioned per symbol.
+# Pandas (src/indicators) stays the per-symbol leaf and the equivalence oracle.
+# --------------------------------------------------------------------------- #
+def _ordered_over(expr: "pl.Expr", by: str, order: str = TS) -> "pl.Expr":
+    """A window expression evaluated per ``by`` group, **sorted by ``order`` within it**.
+
+    A rolling/lagged indicator is meaningless unless the window sees rows in time
+    order, and the on-disk/scan order is not guaranteed to be ts-ascending (multiple
+    row groups, concatenated files, an unsorted write). Passing ``order_by`` makes the
+    window sort *inside* the group, so the result is independent of physical row order
+    — matching the eager :meth:`ParquetBarStore.scan` path, which sorts each symbol by
+    ts. (A post-hoc :func:`sort_canonical` cannot fix this: it reorders the finished
+    output, not the sequence the window was computed over.)
+    """
+    return expr.over(by, order_by=order)
+
+
+def with_sma(
+    lf: "pl.LazyFrame", period: int, *, src: str = "close", out: str = "sma", by: str = SYMBOL
+) -> "pl.LazyFrame":
+    """Add a simple moving average column, per symbol (matches ``calculate_sma``).
+
+    Polars ``rolling_mean`` defaults ``min_periods == window_size``, so the head is
+    null until the window fills — exactly pandas' ``rolling(period).mean()``. The
+    window is ts-ordered within each symbol (see :func:`_ordered_over`).
+    """
+    import polars as pl
+
+    return lf.with_columns(_ordered_over(pl.col(src).rolling_mean(window_size=period), by).alias(out))
+
+
+def with_ema(
+    lf: "pl.LazyFrame", period: int, *, src: str = "close", out: str = "ema", by: str = SYMBOL
+) -> "pl.LazyFrame":
+    """Add an exponential moving average column, per symbol (matches ``calculate_ema``).
+
+    Uses ``adjust=False`` to match pandas' ``ewm(span=period, adjust=False).mean()``
+    (recursive form seeded on the first observation), ts-ordered within each symbol.
+
+    Equivalence holds for a gap-free source. An *interior* null/NaN between two valid
+    bars diverges from pandas: pandas (``ignore_na=False``) decays the weight across the
+    gap, Polars re-weights as if the missing bar were absent. A clean bar series has no
+    interior gaps (the only nulls are the leading warm-up, which agree); feed
+    gap-filled input if a source can drop interior bars.
+    """
+    import polars as pl
+
+    return lf.with_columns(_ordered_over(pl.col(src).ewm_mean(span=period, adjust=False), by).alias(out))
+
+
+def with_returns(
+    lf: "pl.LazyFrame", *, src: str = "close", out: str = "ret", by: str = SYMBOL
+) -> "pl.LazyFrame":
+    """Add a one-bar simple return column, per symbol (matches ``close.pct_change()``).
+
+    ts-ordered within each symbol. Note ``pct_change`` off a zero/again-zero price is a
+    genuine NaN/inf (``0/0``, ``x/0``) just as in pandas; the cross-sectional helpers
+    below treat such non-finite values as missing.
+    """
+    import polars as pl
+
+    return lf.with_columns(_ordered_over(pl.col(src).pct_change(), by).alias(out))
+
+
+# --------------------------------------------------------------------------- #
+# Cross-sectional refinement — Polars ``.over("ts")`` expressions on the panel.
+# src/alphas/refine.py stays the equivalence oracle.
+#
+# Missing-data contract: the pandas oracle (refine.py) runs on ``.dropna()`` — it
+# skips non-finite names and standardises/ranks the rest. Polars reductions skip
+# *null* but PROPAGATE NaN/inf, which would poison the whole cross-section (one NaN
+# score → every name's z collapses to 0; a NaN gets handed the top rank). So each
+# helper first maps non-finite to null via ``_finite`` — then a single contaminated
+# name no longer destroys the rest of the cross-section, matching the oracle.
+# --------------------------------------------------------------------------- #
+def _finite(src: str) -> "pl.Expr":
+    """``src`` with non-finite values (NaN/±inf) mapped to null, so reductions skip them."""
+    import polars as pl
+
+    col = pl.col(src)
+    return pl.when(col.is_finite()).then(col).otherwise(None)
+
+
+def cross_sectional_zscore(
+    lf: "pl.LazyFrame", *, src: str = "score", out: str = "z", by: str = TS
+) -> "pl.LazyFrame":
+    """Cross-sectional z-score ``(x - mean) / std`` per timestamp (matches ``refine.zscore``).
+
+    Uses the population std (``ddof=0``) so the cross-section has unit dispersion.
+    Non-finite names are skipped (null out) exactly as the oracle's ``dropna``; a
+    degenerate cross-section (zero std across the finite names) maps to all-zeros — a
+    universe with no spread expresses no view, the same contract as the pandas oracle.
+    """
+    import polars as pl
+
+    x = _finite(src)
+    mean = x.mean().over(by)
+    std = x.std(ddof=0).over(by)
+    z = (
+        pl.when(x.is_null())  # a missing/non-finite name stays missing (oracle: NaN)
+        .then(None)
+        .when((std == 0) | std.is_null())  # no spread among finite names → no view
+        .then(pl.lit(0.0))
+        .otherwise((x - mean) / std)
+    )
+    return lf.with_columns(z.alias(out))
+
+
+def cross_sectional_winsorize(
+    lf: "pl.LazyFrame",
+    *,
+    src: str = "score",
+    out: Optional[str] = None,
+    lower: float = 0.025,
+    upper: float = 0.975,
+    by: str = TS,
+) -> "pl.LazyFrame":
+    """Clip ``src`` to its ``[lower, upper]`` cross-sectional quantiles (matches ``refine.winsorize``).
+
+    Quantiles use linear interpolation to match pandas' ``Series.quantile`` default and
+    are taken over the finite names only (non-finite stay missing). Writes back into
+    ``src`` unless ``out`` is given.
+    """
+
+    out = out or src
+    x = _finite(src)
+    lo = x.quantile(lower, interpolation="linear").over(by)
+    hi = x.quantile(upper, interpolation="linear").over(by)
+    return lf.with_columns(x.clip(lower_bound=lo, upper_bound=hi).alias(out))
+
+
+def cross_sectional_rank(
+    lf: "pl.LazyFrame", *, src: str = "score", out: str = "rank", by: str = TS
+) -> "pl.LazyFrame":
+    """Add a cross-sectional rank per timestamp (1 = smallest), average ties.
+
+    ``method="average"`` matches pandas' ``Series.rank()`` default. Non-finite names are
+    null (Polars ranks null as null, like pandas), so a missing score is never handed a
+    tradable rank.
+    """
+
+    return lf.with_columns(_finite(src).rank(method="average").over(by).alias(out))
+
+
+def cross_sectional_demean(
+    lf: "pl.LazyFrame", *, src: str = "score", out: str = "z", by: str = TS
+) -> "pl.LazyFrame":
+    """Subtract the cross-sectional mean per timestamp (matches ``refine.demean``).
+
+    Mean is taken over the finite names; non-finite names stay missing.
+    """
+
+    x = _finite(src)
+    return lf.with_columns((x - x.mean().over(by)).alias(out))
+
+
+# --------------------------------------------------------------------------- #
+# Streaming covariance — accumulate cross-products by streaming the return panel
+# instead of materialising the full T×N matrix. src/risk/sample.SampleCovariance
+# is the equivalence oracle (this reproduces its population MLE estimate).
+# --------------------------------------------------------------------------- #
+def streaming_covariance(
+    return_chunks: Iterable[np.ndarray],
+) -> Tuple[np.ndarray, int]:
+    """Per-bar covariance accumulated over chunks of an aligned return panel.
+
+    Each chunk is a ``rows × N`` block of an already-aligned (complete-case) return
+    panel — the same panel :func:`src.risk.base.build_return_panel` produces, but fed
+    in row-chunks so no more than one chunk plus the ``N×N`` accumulator is ever in
+    memory. Memory is bounded by the **universe size**, not the length of history —
+    the point of an out-of-core covariance.
+
+    Accumulates the uncentered sum ``s = Σ xₜ`` and second-moment ``S₂ = Σ xₜxₜᵀ``,
+    then returns the population covariance ``Σ = S₂/n − (s/n)(s/n)ᵀ``. The result
+    matches the single-pass estimate to machine epsilon regardless of how the rows are
+    split (a tested invariant; not byte-identical, since float summation order varies
+    with chunking). The uncentered form is *algebraically* identical to centering first,
+    and *numerically* matches :class:`~src.risk.sample.SampleCovariance` to machine
+    epsilon for the inputs it is contracted on — **return-scale, near-zero-mean** rows
+    (what :func:`src.risk.base.build_return_panel` produces from ``pct_change``). It is
+    NOT for price levels: when the mean dwarfs the spread (|mean| ≫ std), ``S₂/n`` and
+    ``(s/n)(s/n)ᵀ`` are two large near-equal numbers and their difference loses
+    precision (catastrophic cancellation). Feed returns, not levels.
+
+    Returns ``(Σ_per_bar, n_observations)``; with fewer than two observations Σ is the
+    zero matrix (mirroring the oracle's degenerate-case contract).
+    """
+    s: Optional[np.ndarray] = None
+    s2: Optional[np.ndarray] = None
+    count = 0
+    n_cols = 0
+
+    for chunk in return_chunks:
+        x = np.asarray(chunk, dtype=float)
+        if x.ndim != 2 or x.shape[0] == 0:
+            continue
+        if s is None:
+            n_cols = x.shape[1]
+            s = np.zeros(n_cols)
+            s2 = np.zeros((n_cols, n_cols))
+        elif x.shape[1] != n_cols:
+            raise ValueError(f"chunk has {x.shape[1]} columns, expected {n_cols}")
+        s += x.sum(axis=0)
+        s2 += x.T @ x
+        count += x.shape[0]
+
+    if count < 2 or s is None:
+        return np.zeros((n_cols, n_cols)), count
+    mean = s / count
+    cov = s2 / count - np.outer(mean, mean)
+    return cov, count
+
+
+def iter_row_chunks(matrix: np.ndarray, chunk_rows: int) -> Iterable[np.ndarray]:
+    """Yield row-blocks of ``matrix`` of at most ``chunk_rows`` rows.
+
+    The bridge from a materialised return panel to :func:`streaming_covariance`: lets
+    a caller feed an in-memory panel in bounded slices, or a streaming reader hand
+    chunks straight through.
+    """
+    if chunk_rows < 1:
+        raise ValueError("chunk_rows must be >= 1")
+    for start in range(0, len(matrix), chunk_rows):
+        yield matrix[start : start + chunk_rows]
+
+
+# --------------------------------------------------------------------------- #
+# DuckDB SQL path — set-based work over the Parquet store, out-of-core.
+# --------------------------------------------------------------------------- #
+def sql_query(
+    parquet_glob: str | Sequence[str],
+    sql: str,
+    *,
+    params: Optional[Sequence] = None,
+    view: str = "bars",
+) -> "pl.DataFrame":
+    """Run a DuckDB SQL query over Parquet, returned as a Polars frame (zero-copy Arrow).
+
+    Registers ``parquet_glob`` (a path/glob or a list of paths) as a view named
+    ``view`` (default ``bars``) so the query reads ``FROM bars``. DuckDB's reader does
+    its own projection/predicate pushdown and streams the scan, so an aggregation over
+    a multi-file store never materialises the whole thing. The result returns as
+    Polars (shared Arrow) — collapse it to pandas only at the edge via
+    :func:`src.data.edges.to_pandas`.
+
+    ``params`` binds DuckDB ``?`` placeholders (e.g. an ``as_of`` cutoff), keeping the
+    point-in-time filter inside the pushed-down scan rather than a post-filter.
+    """
+    import duckdb
+
+    paths: List[str] = [parquet_glob] if isinstance(parquet_glob, str) else list(parquet_glob)
+    con = duckdb.connect()
+    try:
+        # hive_partitioning=false: the store embeds `symbol` as a real column, so we
+        # must not also synthesise it from the `symbol=…` path (that would collide).
+        # Register the scan as a relation (CREATE VIEW can't take a prepared param).
+        con.register(view, con.read_parquet(paths, hive_partitioning=False))
+        arrow = con.execute(sql, list(params) if params is not None else None).to_arrow_table()
+    finally:
+        con.close()
+
+    import polars as pl
+
+    return pl.from_arrow(arrow)

--- a/src/data/edges.py
+++ b/src/data/edges.py
@@ -1,0 +1,81 @@
+"""The pandas edge — the *only* sanctioned crossings between the lazy columnar core
+and pandas.
+
+The lazy compute model (spec 015) keeps the panel in Arrow/Polars and never
+materialises the whole thing into pandas. But pandas is still the right currency at
+two narrow places: a **per-symbol leaf** where the data is provably small (the
+indicator math the strategy already speaks), and the **final report** a human reads.
+
+Routing every crossing through this module makes the edge *greppable*: a
+``to_pandas`` on a full panel is a bug, not a convenience, and a reviewer can find
+every place the column store collapses to row-major pandas by searching for these
+two functions. Nothing else in the codebase should call ``.to_pandas()`` /
+``pl.from_pandas`` on panel-wide data directly.
+
+Requires the ``store`` extra (``polars``).
+"""
+
+from typing import TYPE_CHECKING, Optional, Union
+
+import pandas as pd
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import polars as pl
+
+
+def to_pandas(
+    frame: Union["pl.DataFrame", "pl.LazyFrame"],
+    *,
+    index: Optional[str] = None,
+    streaming: bool = True,
+) -> pd.DataFrame:
+    """Collapse a Polars frame to pandas — the sanctioned core→edge crossing.
+
+    Accepts either an eager :class:`polars.DataFrame` or a :class:`polars.LazyFrame`;
+    a lazy frame is collected first (with the streaming engine by default, so a large
+    plan materialises in bounded-memory chunks rather than all at once). Pass
+    ``index`` to set a column as the resulting pandas index (e.g. ``"ts"`` for a
+    per-symbol leaf, ``"symbol"`` for a one-timestamp cross-section).
+
+    This is a deliberate narrowing point: call it at a small per-symbol leaf or the
+    final report, never on the full multi-symbol panel.
+    """
+    import polars as pl
+
+    if isinstance(frame, pl.LazyFrame):
+        frame = collect_streaming(frame) if streaming else frame.collect()
+    pdf = frame.to_pandas()
+    if index is not None:
+        if index not in pdf.columns:
+            raise KeyError(f"index column {index!r} not in frame; columns are {list(pdf.columns)}")
+        pdf = pdf.set_index(index)
+    return pdf
+
+
+def from_pandas(df: pd.DataFrame, *, include_index: bool = True) -> "pl.DataFrame":
+    """Lift a pandas frame into Polars — the sanctioned edge→core crossing.
+
+    Used to bring a per-symbol leaf (or a provider frame) back into the columnar
+    core. By default the pandas index is materialised as a column; pass
+    ``include_index=False`` to drop it. A provider/OHLCV frame is typically indexed by
+    an *unnamed* ``DatetimeIndex`` — Polars would materialise that as a column literally
+    named ``"None"``, so we name it first: a ``DatetimeIndex`` becomes ``ts`` (the
+    promise that a time index survives as a real ``ts`` column), any other unnamed
+    index becomes ``index``.
+    """
+    import polars as pl
+
+    if include_index and df.index.name is None:
+        df = df.rename_axis("ts" if isinstance(df.index, pd.DatetimeIndex) else "index")
+    return pl.from_pandas(df, include_index=include_index)
+
+
+def collect_streaming(lazy: "pl.LazyFrame") -> "pl.DataFrame":
+    """Materialise a :class:`polars.LazyFrame` via the **streaming** engine.
+
+    The streaming engine processes the query plan in bounded-memory chunks, so a plan
+    over a larger-than-RAM panel collects without ever holding the whole result. This
+    is the one terminal the lazy helpers in :mod:`src.data.compute` are meant to end
+    on; it lives here (next to ``to_pandas``) because materialising *is* the edge.
+    """
+    return lazy.collect(engine="streaming")

--- a/src/data/features.py
+++ b/src/data/features.py
@@ -1,14 +1,14 @@
 """Feature producers - populate a :class:`FeaturePanel`'s columns from scanned bars.
 
 Each producer is the cross-sectional analog of an indicator: it reads the
-point-in-time bars for the universe and writes one or more feature columns. Today
-there are two - a risk producer (beta + residual volatility, the seed of a future
-risk model) and a generic score producer (apply any per-name scorer). New
-producers (factor exposures, liquidity, transaction-cost params) slot in the same
-way without the consumers above changing.
+point-in-time bars for the universe and writes one or more feature columns. Three
+today - a risk producer (beta + residual volatility), a factor-exposure producer
+(the risk model's standardized exposures, for factor-neutral alphas), and a
+generic score producer (apply any per-name scorer). New producers (liquidity,
+transaction-cost params) slot in the same way without the consumers changing.
 """
 
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Sequence
 
 import pandas as pd
 
@@ -18,6 +18,9 @@ from src.indicators import indicators
 
 #: A scorer reads one symbol's (as-of-sliced) bars and returns a continuous score.
 Scorer = Callable[[pd.DataFrame], float]
+
+#: Panel column prefix for factor-exposure features (``exp_market``, ``exp_size``, ...).
+EXPOSURE_PREFIX = "exp_"
 
 
 def add_risk_features(
@@ -56,6 +59,36 @@ def add_risk_features(
     panel.set("beta", betas)
     panel.set("residual_vol", vols)
     panel.meta["benchmark_available"] = available
+    return panel
+
+
+def add_factor_exposure_features(
+    panel: FeaturePanel,
+    bars: Dict[str, pd.DataFrame],
+    benchmark_bars: Optional[pd.DataFrame],
+    factors: Sequence[str],
+) -> FeaturePanel:
+    """Write standardized risk-model factor exposures as ``exp_<factor>`` columns.
+
+    The columns come from the same exposure builder the factor risk model uses
+    (:func:`src.risk.exposures.build_factor_exposures`), so "factor-neutral" in the
+    alpha pipeline means neutral to the *risk model's* factors — one definition,
+    both places. The market factor reuses the panel's ``beta`` column when present
+    (same regression, already run by :func:`add_risk_features`). If the build
+    qualifies fewer than two names, **no columns are written** — the refinement then
+    falls back to plain-beta neutralisation rather than silently doing nothing.
+    Names missing a single factor get a NaN exposure (mean-imputed downstream).
+    """
+    from src.risk.exposures import build_factor_exposures
+
+    if not list(factors):
+        return panel
+    betas = panel.get("beta") if panel.has("beta") else None
+    frame = build_factor_exposures(bars, benchmark_bars, factors=list(factors), betas=betas)
+    if frame.empty:
+        return panel
+    for name in frame.columns:
+        panel.set(f"{EXPOSURE_PREFIX}{name}", frame[name])
     return panel
 
 

--- a/src/data/store.py
+++ b/src/data/store.py
@@ -14,6 +14,7 @@ appears only at the edge (the returned per-symbol frames), never as the cross-la
 currency. Requires the ``store`` extra (``pyarrow``).
 """
 
+import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
@@ -31,11 +32,18 @@ BAR_COLUMNS = ["ts", "symbol", "open", "high", "low", "close", "volume"]
 
 
 class ParquetBarStore:
-    """A point-in-time :class:`BarSource` backed by symbol-partitioned Parquet.
+    """A point-in-time :class:`BarSource` backed by symbol/date-partitioned Parquet.
 
-    Layout: ``<root>/<timeframe>/symbol=<SYM>/part.parquet``. One timeframe per
-    subtree; the scan prunes by symbol partition and pushes the ``as_of`` window down
-    to the Parquet reader.
+    Layout: ``<root>/<timeframe>/symbol=<SYM>/year=<YYYY>/part.parquet``. One timeframe
+    per subtree, then a Hive ``symbol=…/year=…`` partitioning that serves both access
+    patterns (a symbol's full history, and a date window across symbols). A scan prunes
+    to the **partition files that overlap the date window** (file-level pruning) and
+    then pushes the exact ``as_of`` window into the Parquet reader (row-group pruning),
+    so a one-year scan of a decade-deep store physically opens ~one year of files.
+
+    Year is the partition granularity: coarse enough that daily/most-intraday data
+    keeps a sane file count, fine enough that a typical lookback window touches one or
+    two partitions. Writing a symbol replaces its whole subtree (all years).
     """
 
     def __init__(self, root: str):
@@ -45,7 +53,12 @@ class ParquetBarStore:
     # Write
     # ------------------------------------------------------------------ #
     def write(self, bars: Dict[str, pd.DataFrame], timeframe: TimeframeLike = "1Day") -> None:
-        """Persist ``{symbol: OHLCV}`` to the store (overwriting each symbol's partition)."""
+        """Persist ``{symbol: OHLCV}`` to the store (replacing each symbol's subtree).
+
+        Each symbol's bars are split into ``year=<YYYY>`` partition files (by the bar's
+        UTC year, the same basis the scan window prunes on). The symbol's existing
+        subtree is removed first so a rewrite never leaves a stale year partition behind.
+        """
         import pyarrow as pa
         import pyarrow.parquet as pq
 
@@ -53,10 +66,15 @@ class ParquetBarStore:
         for symbol, frame in bars.items():
             if frame is None or frame.empty:
                 continue
-            table = pa.Table.from_pandas(self._to_records(symbol, frame), preserve_index=False)
-            part = self.root / tf / f"symbol={symbol}"
-            part.mkdir(parents=True, exist_ok=True)
-            pq.write_table(table, part / "part.parquet")
+            records = self._to_records(symbol, frame)
+            sdir = self._symbol_dir(tf, symbol)
+            if sdir.exists():
+                shutil.rmtree(sdir)  # full replace: no stale year partitions survive
+            for year, group in records.groupby(records["ts"].dt.year):
+                part = sdir / f"year={int(year)}"
+                part.mkdir(parents=True, exist_ok=True)
+                table = pa.Table.from_pandas(group, preserve_index=False)
+                pq.write_table(table, part / "part.parquet")
 
     # ------------------------------------------------------------------ #
     # Scan (the BarSource contract)
@@ -66,26 +84,24 @@ class ParquetBarStore:
     ) -> Dict[str, pd.DataFrame]:
         """Return ``{symbol: OHLCV}`` over ``(as_of - lookback, as_of]`` — pushed down.
 
-        The timestamp window is a Parquet filter, so rows outside it (in particular any
-        bar *after* ``as_of``) are never read into memory.
+        Only the ``year=`` partition files overlapping the window are opened (file-level
+        pruning), and the timestamp window is then a Parquet filter, so rows outside it
+        (in particular any bar *after* ``as_of``) are never read into memory.
         """
         import pyarrow.compute as pc
         import pyarrow.dataset as ds
 
         tf = str(Timeframe.parse(timeframe) if isinstance(timeframe, str) else timeframe)
-        root = self.root / tf
-        if not root.exists():
+        if not (self.root / tf).exists():
             return {}
 
-        end = pd.Timestamp(as_of)
-        end = end.tz_localize("UTC") if end.tzinfo is None else end.tz_convert("UTC")
-        start = end - timedelta(days=lookback_days)
+        start, end = self._window(as_of, lookback_days)
         out: Dict[str, pd.DataFrame] = {}
         for symbol in dict.fromkeys(universe):
-            part = root / f"symbol={symbol}"
-            if not part.exists():
+            files = self._window_files(tf, symbol, start, end)
+            if not files:
                 continue
-            dataset = ds.dataset(part, format="parquet")
+            dataset = ds.dataset(files, format="parquet")
             # Predicate pushdown: only ts in (start, end] is read off disk.
             table = dataset.to_table(filter=(pc.field("ts") > start) & (pc.field("ts") <= end))
             if table.num_rows:
@@ -93,24 +109,65 @@ class ParquetBarStore:
         return out
 
     # ------------------------------------------------------------------ #
-    # Lazy scan (the out-of-core compute seam, spec 015)
+    # Partition geometry (symbol=…/year=… Hive layout)
     # ------------------------------------------------------------------ #
     def _tf_root(self, timeframe: TimeframeLike) -> Path:
         tf = str(Timeframe.parse(timeframe) if isinstance(timeframe, str) else timeframe)
         return self.root / tf
 
-    def partition_paths(self, universe: Sequence[str], timeframe: TimeframeLike = "1Day") -> List[str]:
-        """The Parquet file paths backing ``universe`` (existing partitions only).
+    def _symbol_dir(self, tf: str, symbol: str) -> Path:
+        return self.root / tf / f"symbol={symbol}"
 
-        The glob a DuckDB/Polars set-based query (:func:`src.data.compute.sql_query`)
-        reads over — one file per symbol partition that actually exists.
+    @staticmethod
+    def _window(as_of: datetime, lookback_days: int) -> tuple:
+        """Normalise ``as_of`` to UTC and return the ``(start, end]`` window."""
+        end = pd.Timestamp(as_of)
+        end = end.tz_localize("UTC") if end.tzinfo is None else end.tz_convert("UTC")
+        return end - timedelta(days=lookback_days), end
+
+    def _year_files(self, sdir: Path, lo_year: Optional[int], hi_year: Optional[int]) -> List[str]:
+        """``part.parquet`` paths in ``sdir``'s ``year=`` partitions within ``[lo, hi]``."""
+        if not sdir.exists():
+            return []
+        files = []
+        for ydir in sorted(sdir.glob("year=*")):
+            try:
+                year = int(ydir.name.split("=", 1)[1])
+            except (IndexError, ValueError):
+                continue
+            if (lo_year is None or year >= lo_year) and (hi_year is None or year <= hi_year):
+                part = ydir / "part.parquet"
+                if part.exists():
+                    files.append(str(part))
+        return files
+
+    def _window_files(self, tf: str, symbol: str, start: pd.Timestamp, end: pd.Timestamp) -> List[str]:
+        """The partition files for ``symbol`` overlapping ``[start.year, end.year]``."""
+        return self._year_files(self._symbol_dir(tf, symbol), start.year, end.year)
+
+    def partition_paths(
+        self,
+        universe: Sequence[str],
+        timeframe: TimeframeLike = "1Day",
+        as_of: Optional[datetime] = None,
+        lookback_days: int = 365,
+    ) -> List[str]:
+        """The Parquet partition files backing ``universe`` (existing partitions only).
+
+        The file list a DuckDB/Polars set-based query (:func:`src.data.compute.sql_query`)
+        or :meth:`scan_lazy` reads over. With ``as_of`` given the list is pruned to the
+        ``year=`` partitions overlapping ``(as_of - lookback, as_of]`` (file-level
+        date pruning); without it, every year partition for the symbols is returned.
         """
-        root = self._tf_root(timeframe)
-        paths = []
+        tf = str(Timeframe.parse(timeframe) if isinstance(timeframe, str) else timeframe)
+        if as_of is None:
+            lo_year = hi_year = None
+        else:
+            start, end = self._window(as_of, lookback_days)
+            lo_year, hi_year = start.year, end.year
+        paths: List[str] = []
         for symbol in dict.fromkeys(universe):
-            part = root / f"symbol={symbol}" / "part.parquet"
-            if part.exists():
-                paths.append(str(part))
+            paths.extend(self._year_files(self._symbol_dir(tf, symbol), lo_year, hi_year))
         return paths
 
     def scan_lazy(
@@ -150,16 +207,15 @@ class ParquetBarStore:
             "volume": pl.Float64,
         }
 
-        paths = self.partition_paths(universe, timeframe)
+        # File-level date pruning: only year partitions overlapping the window.
+        paths = self.partition_paths(universe, timeframe, as_of=as_of, lookback_days=lookback_days)
         if not paths:
             empty = pl.DataFrame(schema=schema).lazy()
             if columns is not None:
                 empty = empty.select(list(dict.fromkeys(["ts", "symbol", *columns])))
             return empty
 
-        end = pd.Timestamp(as_of)
-        end = end.tz_localize("UTC") if end.tzinfo is None else end.tz_convert("UTC")
-        start = end - timedelta(days=lookback_days)
+        start, end = self._window(as_of, lookback_days)
         # hive_partitioning=false: `symbol` is a real column in each file; don't also
         # synthesise it from the `symbol=…` directory (that collides).
         lf = pl.scan_parquet(paths, hive_partitioning=False)

--- a/src/data/store.py
+++ b/src/data/store.py
@@ -16,12 +16,15 @@ currency. Requires the ``store`` extra (``pyarrow``).
 
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, List
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence
 
 import pandas as pd
 
 from src.marketdata.client import TimeframeLike
 from src.marketdata.timeframe import Timeframe
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import polars as pl
 
 #: The enforced bar schema columns (the Arrow boundary contract).
 BAR_COLUMNS = ["ts", "symbol", "open", "high", "low", "close", "volume"]
@@ -88,6 +91,85 @@ class ParquetBarStore:
             if table.num_rows:
                 out[symbol] = self._from_records(table.to_pandas())
         return out
+
+    # ------------------------------------------------------------------ #
+    # Lazy scan (the out-of-core compute seam, spec 015)
+    # ------------------------------------------------------------------ #
+    def _tf_root(self, timeframe: TimeframeLike) -> Path:
+        tf = str(Timeframe.parse(timeframe) if isinstance(timeframe, str) else timeframe)
+        return self.root / tf
+
+    def partition_paths(self, universe: Sequence[str], timeframe: TimeframeLike = "1Day") -> List[str]:
+        """The Parquet file paths backing ``universe`` (existing partitions only).
+
+        The glob a DuckDB/Polars set-based query (:func:`src.data.compute.sql_query`)
+        reads over — one file per symbol partition that actually exists.
+        """
+        root = self._tf_root(timeframe)
+        paths = []
+        for symbol in dict.fromkeys(universe):
+            part = root / f"symbol={symbol}" / "part.parquet"
+            if part.exists():
+                paths.append(str(part))
+        return paths
+
+    def scan_lazy(
+        self,
+        universe: List[str],
+        timeframe: TimeframeLike,
+        as_of: datetime,
+        lookback_days: int = 365,
+        columns: Optional[Sequence[str]] = None,
+    ) -> "pl.LazyFrame":
+        """Return a **lazy** long-format panel for ``universe`` over ``(as_of - lookback, as_of]``.
+
+        The compute-tier counterpart to :meth:`scan`: instead of materialising
+        per-symbol pandas frames, it returns a Polars :class:`~polars.LazyFrame` over
+        the Parquet partitions with the ``as_of`` window pushed into the reader as a
+        predicate (rows after ``as_of`` are physically never read) and an optional
+        column projection pushed down too. ``as_of`` may be naive (treated as UTC) or
+        tz-aware; the window matches the eager :meth:`scan` exactly (strict ``>`` on the
+        lower bound, ``<=`` on ``as_of``). Nothing executes until a terminal collect
+        (:func:`src.data.edges.collect_streaming`). The leaf scan + pushdown stream; a
+        downstream ``over(...)``/sort buffers (see :mod:`src.data.compute` on what is
+        genuinely bounded-memory). Requires the ``store`` extra (``polars``).
+
+        An empty universe yields an empty but **schema-carrying** LazyFrame, so a
+        window helper composed onto it resolves its source column and returns an empty
+        frame rather than raising (the lazy analogue of :meth:`scan` returning ``{}``).
+        """
+        import polars as pl
+
+        schema = {
+            "ts": pl.Datetime("us", "UTC"),
+            "symbol": pl.Utf8,
+            "open": pl.Float64,
+            "high": pl.Float64,
+            "low": pl.Float64,
+            "close": pl.Float64,
+            "volume": pl.Float64,
+        }
+
+        paths = self.partition_paths(universe, timeframe)
+        if not paths:
+            empty = pl.DataFrame(schema=schema).lazy()
+            if columns is not None:
+                empty = empty.select(list(dict.fromkeys(["ts", "symbol", *columns])))
+            return empty
+
+        end = pd.Timestamp(as_of)
+        end = end.tz_localize("UTC") if end.tzinfo is None else end.tz_convert("UTC")
+        start = end - timedelta(days=lookback_days)
+        # hive_partitioning=false: `symbol` is a real column in each file; don't also
+        # synthesise it from the `symbol=…` directory (that collides).
+        lf = pl.scan_parquet(paths, hive_partitioning=False)
+        # Predicate pushdown: the window (in particular the as_of upper bound) is
+        # pushed into the Parquet SCAN, so post-as_of rows are never read.
+        lf = lf.filter((pl.col("ts") > pl.lit(start)) & (pl.col("ts") <= pl.lit(end)))
+        if columns is not None:
+            keep = list(dict.fromkeys(["ts", "symbol", *columns]))
+            lf = lf.select(keep)
+        return lf
 
     # ------------------------------------------------------------------ #
     # The pandas edge (the only sanctioned crossings)

--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -1,0 +1,6 @@
+"""TradeFlow MCP server package.
+
+Opt-in: requires the ``mcp`` extra (``uv sync --extra mcp``). The ``mcp`` import
+lives only inside :mod:`src.mcp.server` and is imported lazily by the ``mcp``
+subcommand, so the base install and other commands never pull it in.
+"""

--- a/src/portfolio/optimizer.py
+++ b/src/portfolio/optimizer.py
@@ -4,19 +4,29 @@ The OR-Tools :class:`~src.portfolio.allocator.PortfolioAllocator` maximises a sc
 score subject to constraints - it has no notion of risk, so it piles weight onto the
 highest-scoring names regardless of how correlated they are. Active-management
 construction instead maximises a **risk-adjusted utility**, trading expected residual
-return (alpha, Spec 005) against active risk (covariance, Spec 006):
+return (alpha, Spec 005) against active risk (covariance, Spec 006) - and, once cost is
+in the objective (Spec 016), against the *name-specific* cost of getting there:
 
-    U(w) = αᵀw − λ_A · wᵀΣw            (long-only absolute: benchmark w_B = 0)
+    U(w) = αᵀw − λ_A · wᵀΣw − Σᵢ cᵢ·|Δwᵢ| − Σᵢ kᵢ·|Δwᵢ|^{3/2}      (Δw = w − w₀)
+           └ value ┘  └ active risk ┘  └ linear turnover ┘  └ √-impact (conic) ┘
 
 The output is the portfolio that maximises the *information ratio you can actually
-implement*, plus the Fundamental-Law diagnostics that make the cost of every
-constraint visible. This is **research-clock**: it proposes target weights (a config a
-human promotes), it never places an order - so it lives apart from the operational
-position sizer.
+implement net of cost*, plus the Fundamental-Law diagnostics that make the cost of
+every constraint visible. This is **research-clock**: it proposes target weights (a
+config a human promotes), it never places an order - so it lives apart from the
+operational position sizer.
 
-Pure numpy: the unconstrained optimum is closed-form; the constrained (long-only, box,
-budget, cardinality) optimum is a small convex QP solved by projected gradient with a
-capped-simplex projection - no heavyweight QP dependency.
+Pure numpy - no heavyweight QP/conic dependency. The unconstrained cost-free optimum is
+closed-form; the constrained problem (long-only, box, budget, cardinality) is a small
+convex program solved by **proximal gradient**. The cost term is nonsmooth but convex,
+so it enters through the proximal step: after each gradient step on the smooth part we
+apply the exact proximal operator of ``cᵢ·|Δwᵢ| + kᵢ·|Δwᵢ|^{3/2}`` *composed with* the
+capped-simplex projection. That proximal operator is separable per name given a single
+budget dual, and each coordinate has a closed form (a soft-threshold *around w₀* for the
+linear cost; a quadratic-in-√ root for the √-impact) - so the whole conic problem is
+solved by the same 1-D budget bisection the cost-free projection already used, with no
+external solver. When ``cᵢ = kᵢ = 0`` it reduces *exactly* to the cost-free projected
+gradient, so Spec 008's behaviour is unchanged.
 """
 
 from dataclasses import dataclass, field
@@ -25,7 +35,23 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from src.alphas.base import Alpha
+from src.costs.base import CostModel
 from src.risk.base import RiskMatrix
+
+
+@dataclass
+class CostInputs:
+    """Per-name, as-of liquidity context the cost model prices trades against.
+
+    Threaded from Spec 007: a fractional ``spread`` (quoted, or a high-low-range proxy),
+    trailing ``adv_dollar`` (ADV in dollars = price · share-ADV), and trailing
+    ``daily_vol`` (daily return volatility). All keyed by symbol; missing names fall
+    back to the cost model's defaults (spread) or drop the √-impact term (ADV/vol).
+    """
+
+    spread: Dict[str, float] = field(default_factory=dict)
+    adv_dollar: Dict[str, float] = field(default_factory=dict)
+    daily_vol: Dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -40,7 +66,7 @@ class PortfolioResult:
 
 
 class MeanVarianceOptimizer:
-    """Maximise ``αᵀw − λ·wᵀΣw`` over long-only, box-bounded, budgeted weights."""
+    """Maximise ``αᵀw − λ·wᵀΣw − cost(w − w₀)`` over long-only, box, budgeted weights."""
 
     def __init__(
         self,
@@ -58,6 +84,8 @@ class MeanVarianceOptimizer:
         self.max_weight = max_weight
         self.min_weight = min_weight  # minimum weight for a *held* name (a dust floor)
         self.max_names = max_names
+        # Manual override retained for backward-compat / the cost-free case; when a cost
+        # model is supplied the no-trade band *emerges* from the cost (see optimize()).
         self.no_trade_band = no_trade_band
         self.max_iter = max_iter
         self.tol = tol
@@ -70,14 +98,28 @@ class MeanVarianceOptimizer:
         target_te: Optional[float] = None,
         risk_aversion: Optional[float] = None,
         current_weights: Optional[Dict[str, float]] = None,
+        cost_model: Optional[CostModel] = None,
+        cost_inputs: Optional[CostInputs] = None,
+        capital: Optional[float] = None,
+        holding_period_years: float = 1.0 / 12.0,
     ) -> PortfolioResult:
         """Construct the utility-maximising portfolio over the alpha/risk universe.
 
         Supply *either* ``target_te`` (the intuitive knob - "run at 4% tracking
-        error") *or* ``risk_aversion`` (``λ_A`` directly). ``current_weights`` (``w_0``)
-        is where turnover is measured from. Returns the weights, the diagnostics
-        (``IR*``, predicted TE/IR, transfer coefficient, value added, turnover), and a
-        feasibility verdict naming the binding constraint when infeasible.
+        error") *or* ``risk_aversion`` (``λ_A`` directly). ``current_weights`` (``w₀``)
+        is where turnover is measured from.
+
+        Pass a ``cost_model`` + ``cost_inputs`` to make the solve **cost-aware** (Spec
+        016): the objective gains a name-specific linear turnover penalty and, when
+        ``capital`` is given, the √-impact term. Cost coefficients are *annualised* to
+        the same units as the (annualised) alpha by dividing the one-way rate by
+        ``holding_period_years`` - matching Spec 007's alpha-haircut and the ex-post
+        cost drag. Without a cost model the solve is cost-blind (Spec 008, unchanged).
+
+        Returns the weights, the diagnostics (``IR*``, predicted TE/IR, transfer
+        coefficient, value added, turnover, and - when cost-aware - the linear/impact
+        cost split and net expected return), and a feasibility verdict naming the
+        binding constraint when infeasible.
         """
         symbols, alpha = self._align(alphas, risk)
         if len(symbols) == 0:
@@ -87,12 +129,12 @@ class MeanVarianceOptimizer:
         n = len(symbols)
 
         # Cardinality + box can make the budget unreachable: name the binding bound.
-        k = min(self.max_names or n, n)
-        if k * self.max_weight < 1.0 - 1e-9:
+        k_cap = min(self.max_names or n, n)
+        if k_cap * self.max_weight < 1.0 - 1e-9:
             return PortfolioResult(
                 weights={},
                 feasible=False,
-                binding_constraint=f"max_weight*{k} < 1 (cardinality/weight cap can't fund the book)",
+                binding_constraint=f"max_weight*{k_cap} < 1 (cardinality/weight cap can't fund the book)",
             )
 
         sigma_inv = np.linalg.inv(sigma)
@@ -101,14 +143,23 @@ class MeanVarianceOptimizer:
         lam = self._risk_aversion(ir_star, target_te, risk_aversion)
         unconstrained = (sigma_inv @ alpha) / (2.0 * lam)
 
-        w = self._constrained_solve(alpha, sigma, lam, n)
-
         w0 = self._vector(current_weights or {}, symbols)
-        # No-trade band: if every name moves less than the band, don't churn.
+        # Per-name cost coefficients (annualised), aligned to `symbols`. Both zero when
+        # cost-blind -> the solve reduces exactly to Spec 008's projected gradient.
+        c_lin, k_imp = self._cost_coefficients(
+            cost_model, cost_inputs, capital, holding_period_years, symbols
+        )
+        cost_aware = bool(np.any(c_lin > 0) or np.any(k_imp > 0))
+
+        w = self._constrained_solve(alpha, sigma, lam, n, c_lin, k_imp, w0)
+
+        # Manual no-trade band (cost-free override): if every name moves less than the
+        # band, don't churn. When cost-aware the band instead *emerges* from c_lin (a
+        # name stays at w₀ⁱ while its marginal value is inside ±cᵢ), so this is a no-op.
         if self.no_trade_band > 0 and np.max(np.abs(w - w0)) < self.no_trade_band:
             w = w0.copy()
 
-        diagnostics = self._diagnostics(alpha, sigma, w, w0, lam, ir_star)
+        diagnostics = self._diagnostics(alpha, sigma, w, w0, lam, ir_star, c_lin, k_imp, cost_aware)
         return PortfolioResult(
             weights={s: float(w[i]) for i, s in enumerate(symbols) if w[i] > 1e-9},
             feasible=True,
@@ -117,23 +168,57 @@ class MeanVarianceOptimizer:
         )
 
     # ------------------------------------------------------------------ #
+    # Cost coefficients
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _cost_coefficients(cost_model, cost_inputs, capital, holding_period_years, symbols):
+        """Build the annualised per-name linear (``cᵢ``) and √-impact (``kᵢ``) vectors.
+
+        ``cᵢ = turnover_cost_rate(spreadᵢ) / h`` (one-way commission+half-spread, per
+        year); ``kᵢ = impact_coefficient(σᵢ, ADV$ᵢ, capital) / h`` (per year), and
+        ``kᵢ = 0`` when ``capital`` is absent - the "ship linear first" default. Zero
+        vectors when no cost model is supplied.
+        """
+        n = len(symbols)
+        c_lin = np.zeros(n)
+        k_imp = np.zeros(n)
+        if cost_model is None or cost_inputs is None:
+            return c_lin, k_imp
+        h = max(holding_period_years, 1e-9)
+        have_capital = capital is not None and capital > 0
+        for i, s in enumerate(symbols):
+            spread = cost_inputs.spread.get(s)
+            c_lin[i] = cost_model.turnover_cost_rate(spread) / h
+            if have_capital:
+                adv_dollar = cost_inputs.adv_dollar.get(s, 0.0)
+                daily_vol = cost_inputs.daily_vol.get(s, 0.0)
+                k_imp[i] = cost_model.impact_coefficient(daily_vol, adv_dollar, capital) / h
+        # A non-finite input (e.g. a NaN spread proxy) must drop that name's cost term,
+        # not poison the whole solve with a NaN coefficient (which would empty the book).
+        c_lin = np.where(np.isfinite(c_lin), c_lin, 0.0)
+        k_imp = np.where(np.isfinite(k_imp), k_imp, 0.0)
+        return c_lin, k_imp
+
+    # ------------------------------------------------------------------ #
     # Solve
     # ------------------------------------------------------------------ #
-    def _constrained_solve(self, alpha: np.ndarray, sigma: np.ndarray, lam: float, n: int) -> np.ndarray:
-        """Box+budget QP, plus the two non-convex constraints handled by re-solving.
+    def _constrained_solve(self, alpha, sigma, lam, n, c_lin, k_imp, w0) -> np.ndarray:
+        """Box+budget convex program, plus the two non-convex constraints by re-solving.
 
         Cardinality (``‖w‖₀ ≤ max_names``) and the semi-continuous dust floor
         (``w ∈ {0} ∪ [min_weight, max_weight]``) are both non-convex, so each is
-        enforced the same pragmatic way: solve the convex QP, drop the offending
-        names (the smallest beyond the cardinality cap, or any stuck in the
-        ``(0, min_weight)`` hole), and re-solve on the survivors until stable.
+        enforced the same pragmatic way: solve the convex (now cost-aware) program, drop
+        the offending names (the smallest beyond the cardinality cap, or any stuck in
+        the ``(0, min_weight)`` hole), and re-solve on the survivors until stable. A
+        dropped held name is a full liquidation of ``w₀ⁱ``; its cost is captured in the
+        final diagnostics, which price ``w − w₀`` over the full universe.
         """
         active = np.arange(n)
-        w = self._solve(alpha, sigma, lam, active)
+        w = self._solve(alpha, sigma, lam, active, c_lin, k_imp, w0)
 
         if self.max_names is not None and int(np.sum(w > 1e-9)) > self.max_names:
             active = np.argsort(w)[::-1][: self.max_names]
-            w = self._solve(alpha, sigma, lam, active)
+            w = self._solve(alpha, sigma, lam, active, c_lin, k_imp, w0)
 
         # Dust floor: drop held names below min_weight and re-solve, while the budget
         # stays fundable (enough remaining names at max_weight to reach 1).
@@ -144,20 +229,35 @@ class MeanVarianceOptimizer:
                 break  # every held name clears the floor
             if len(keep) == 0 or len(keep) * self.max_weight < 1.0 - 1e-9:
                 break  # dropping further would make the budget infeasible
-            w = self._solve(alpha, sigma, lam, keep)
+            w = self._solve(alpha, sigma, lam, keep, c_lin, k_imp, w0)
         return w
 
-    def _solve(self, alpha: np.ndarray, sigma: np.ndarray, lam: float, active: np.ndarray) -> np.ndarray:
-        """Projected-gradient QP over the active names; full-length weight vector out."""
+    def _solve(self, alpha, sigma, lam, active, c_lin, k_imp, w0) -> np.ndarray:
+        """Proximal-gradient solve over the active names; full-length weight vector out.
+
+        Minimises ``f(w) + g(w)`` with smooth ``f = −αᵀw + λwᵀΣw`` and nonsmooth convex
+        ``g = Σ cᵢ|wᵢ−w₀ⁱ| + Σ kᵢ|wᵢ−w₀ⁱ|^{3/2} + ι_{box∩budget}``. Each iteration is a
+        gradient step on ``f`` followed by the exact proximal operator of ``g`` (see
+        :meth:`_prox_project`). Step ``1/L`` with ``L = 2λ·λmax(Σ)`` guarantees
+        convergence; ``λmin(Σ) > 0`` makes ``f`` strongly convex, so it is linear.
+        """
         n = len(alpha)
-        a, s = alpha[active], sigma[np.ix_(active, active)]
+        a = alpha[active]
+        s = sigma[np.ix_(active, active)]
+        c = c_lin[active]
+        k = k_imp[active]
+        w0a = w0[active]
         # Lipschitz constant of ∇f = -a + 2λ·s·w is 2λ·λmax(s); step = 1/L.
         lmax = float(np.linalg.eigvalsh(s).max())
         step = 1.0 / (2.0 * lam * lmax) if lmax > 0 else 1.0
-        w = self._project(np.ones(len(active)) / len(active))
+        thr = step * c
+        kthr = step * k
+        # Warm-start from w₀ (projected) when it holds weight, else uniform.
+        start = w0a if w0a.sum() > 1e-9 else np.ones(len(active)) / len(active)
+        w = self._prox_project(start, np.zeros_like(thr), np.zeros_like(kthr), w0a)
         for _ in range(self.max_iter):
             grad = -a + 2.0 * lam * (s @ w)
-            nxt = self._project(w - step * grad)
+            nxt = self._prox_project(w - step * grad, thr, kthr, w0a)
             if np.max(np.abs(nxt - w)) < self.tol:
                 w = nxt
                 break
@@ -166,18 +266,59 @@ class MeanVarianceOptimizer:
         full[active] = w
         return full
 
-    def _project(self, y: np.ndarray) -> np.ndarray:
-        """Euclidean projection onto {0 ≤ w ≤ max_weight, Σw = 1} (capped simplex)."""
-        c, target = self.max_weight, 1.0
-        lo, hi = float(y.min() - c), float(y.max())
+    def _prox_project(self, y: np.ndarray, thr: np.ndarray, kthr: np.ndarray, w0: np.ndarray) -> np.ndarray:
+        """Exact prox of the cost + capped-simplex indicator, via a budget bisection.
+
+        Solves ``argmin_w ½‖w−y‖² + Σ thrᵢ|wᵢ−w₀ⁱ| + Σ kthrᵢ|wᵢ−w₀ⁱ|^{3/2}`` over
+        ``{0 ≤ w ≤ cap, Σw = 1}``. With a single dual ``τ`` for the budget it separates
+        per coordinate: ``wᵢ(τ) = clip(w₀ⁱ + d*((yᵢ−τ)−w₀ⁱ), 0, cap)`` where ``d*`` is
+        the per-name proximal step (:meth:`_prox_step`). Each ``wᵢ(τ)`` is monotone
+        non-increasing in ``τ``, so ``Σwᵢ(τ) = 1`` is found by bisection - the same
+        1-D structure the cost-free projection used. With ``thr = kthr = 0`` the
+        coordinate map is ``clip(yᵢ − τ, 0, cap)`` and this is exactly that projection.
+        """
+        cap = self.max_weight
+
+        def total(tau: float) -> float:
+            m = (y - tau) - w0
+            return float(np.clip(w0 + self._prox_step(m, thr, kthr), 0.0, cap).sum())
+
+        pad = float(thr.max()) if thr.size else 0.0
+        lo = float(y.min() - cap - pad)
+        hi = float(y.max() + pad)
+        # Guarantee the budget root is bracketed (total is monotone non-increasing in τ).
+        guard = 0
+        while total(lo) < 1.0 and guard < 200:
+            lo -= abs(lo) + 1.0
+            guard += 1
+        guard = 0
+        while total(hi) > 1.0 and guard < 200:
+            hi += abs(hi) + 1.0
+            guard += 1
         for _ in range(100):
             tau = 0.5 * (lo + hi)
-            total = np.clip(y - tau, 0.0, c).sum()
-            if total > target:
+            if total(tau) > 1.0:
                 lo = tau
             else:
                 hi = tau
-        return np.clip(y - 0.5 * (lo + hi), 0.0, c)
+        tau = 0.5 * (lo + hi)
+        m = (y - tau) - w0
+        return np.clip(w0 + self._prox_step(m, thr, kthr), 0.0, cap)
+
+    @staticmethod
+    def _prox_step(m: np.ndarray, thr: np.ndarray, kthr: np.ndarray) -> np.ndarray:
+        """Per-name trade ``d* = argmin_d ½(d−m)² + thr|d| + kthr|d|^{3/2}`` (unclipped).
+
+        Closed form: ``d* = 0`` when ``|m| ≤ thr`` (the emergent no-trade band - a name
+        is untraded while its move is inside the linear cost); otherwise, with residual
+        ``r = |m| − thr`` and ``b = 3·kthr/2``, the magnitude solves ``u² + b·u = r``
+        (``u = √|d|``), i.e. ``u = (−b + √(b² + 4r))/2`` and ``d* = sign(m)·u²``. With
+        ``kthr = 0`` this is the ordinary soft-threshold ``sign(m)·max(|m|−thr, 0)``.
+        """
+        residual = np.maximum(np.abs(m) - thr, 0.0)
+        b = 1.5 * kthr
+        u = (-b + np.sqrt(b * b + 4.0 * residual)) / 2.0
+        return np.sign(m) * u * u
 
     # ------------------------------------------------------------------ #
     # Calibration & diagnostics
@@ -189,25 +330,51 @@ class MeanVarianceOptimizer:
             return ir_star / (2.0 * target_te)  # λ_A = IR* / (2·ψ_target)
         return 1.0  # neutral default when neither is usable
 
-    def _diagnostics(self, alpha, sigma, w, w0, lam, ir_star) -> Dict[str, float]:
+    def _diagnostics(self, alpha, sigma, w, w0, lam, ir_star, c_lin, k_imp, cost_aware) -> Dict[str, float]:
         sig_w = sigma @ w
         active_variance = float(w @ sig_w)
         te = float(np.sqrt(max(active_variance, 0.0)))
         expected = float(alpha @ w)
         # Transfer coefficient: corr(α, Σ-adjusted active weights) ∈ [-1, 1].
         tc = self._corr(alpha, sig_w)
-        return {
+        dw = w - w0
+        diagnostics = {
             "ir_star": ir_star,
             "risk_aversion": float(lam),
             "expected_active_return": expected,
-            "predicted_tracking_error": te,
+            "predicted_tracking_error": te,  # realised TE at the (cost-bent) optimum
             "predicted_ir": expected / te if te > 0 else 0.0,
             "transfer_coefficient": tc,
             "ir_achieved": tc * ir_star,
             "optimal_tracking_error": ir_star / (2.0 * lam) if lam > 0 else 0.0,
             "value_added": (ir_star**2) / (4.0 * lam) if lam > 0 else 0.0,
-            "turnover": float(np.sum(np.abs(w - w0))),
+            "turnover": float(np.sum(np.abs(dw))),
         }
+        if cost_aware:
+            # One-way cost of *this rebalance's* turnover - what the objective charged,
+            # kept for continuity with the prior (pre-016) ex-post drag. Detail.
+            linear_cost = float(np.sum(c_lin * np.abs(dw)))
+            impact_cost = float(np.sum(k_imp * np.abs(dw) ** 1.5))
+            rebalance_cost = linear_cost + impact_cost
+            # Round-trip haircut on the *held book* (007 §3.2 / the capacity convention):
+            # entering AND exiting each position, amortised over the holding period. This
+            # is the conservative headline net figure - the same cost model _capacity
+            # prices, so the net return and the capacity number agree.
+            book = np.abs(w)
+            round_trip_cost = float(2.0 * (np.sum(c_lin * book) + np.sum(k_imp * book**1.5)))
+            diagnostics.update(
+                {
+                    "cost_aware": True,
+                    "linear_cost": linear_cost,  # one-way Σ cᵢ|Δwᵢ| (rebalance turnover)
+                    "impact_cost": impact_cost,  # one-way Σ kᵢ|Δwᵢ|^{3/2} (rebalance √-impact)
+                    "cost_drag": rebalance_cost,  # one-way rebalance total (continuity)
+                    "round_trip_cost": round_trip_cost,  # round-trip book haircut (headline)
+                    "expected_active_return_net": expected - round_trip_cost,  # headline: round-trip
+                    "expected_active_return_net_oneway": expected - rebalance_cost,  # detail: one-way
+                    "names_traded": int(np.sum(np.abs(dw) > 1e-9)),
+                }
+            )
+        return diagnostics
 
     # ------------------------------------------------------------------ #
     # Alignment helpers

--- a/src/research/__init__.py
+++ b/src/research/__init__.py
@@ -1,0 +1,30 @@
+"""Autonomous research agent (opt-in behind the ``ai`` extra).
+
+A bounded, offline research loop: propose a hypothesis -> express it as a config
+(or, behind a flag, as new strategy code) -> validate it out-of-sample with
+walk-forward -> keep/discard -> repeat until budget or dryness -> score the
+survivors once on the sacred holdout -> hand a human a shortlist.
+
+The agent reuses the *same* :mod:`src.services` core as the MCP server, so there
+is one code path. It never touches live trading, never toggles ``PAPER_TRADE``,
+and is scored exclusively on out-of-sample output (see :mod:`src.research.agent`
+for the non-negotiable guardrails). The proposer is provider-agnostic - Claude,
+OpenAI, or a local Ollama model (see :mod:`src.research.llm`).
+"""
+
+from src.research.agent import Candidate, ResearchAgent, ResearchConfig, ResearchResult
+from src.research.llm import build_llm_client
+from src.research.proposer import FixedProposer, LLMProposer, Proposal, Proposer, build_proposer
+
+__all__ = [
+    "ResearchAgent",
+    "ResearchConfig",
+    "ResearchResult",
+    "Candidate",
+    "Proposer",
+    "Proposal",
+    "FixedProposer",
+    "LLMProposer",
+    "build_proposer",
+    "build_llm_client",
+]

--- a/src/risk/__init__.py
+++ b/src/risk/__init__.py
@@ -1,0 +1,42 @@
+"""Risk model: the covariance matrix Σ and the quantities built on it.
+
+Active management needs a structural answer to "how risky is this portfolio?" that
+respects the fact that risk is not additive. This module estimates an annualised,
+well-conditioned, invertible Σ over a universe (Ledoit–Wolf shrinkage in v1) and
+exposes portfolio variance, tracking error, and marginal contribution to risk.
+Research-clock only: Σ sizes conviction, it never reaches the order path.
+"""
+
+from src.risk.base import RiskMatrix, RiskModel, build_return_panel, build_risk_matrix
+from src.risk.exposures import FACTOR_NAMES, build_factor_exposures
+from src.risk.factor import FactorRiskMatrix, build_factor_risk_matrix, estimate_factor_model
+from src.risk.sample import LedoitWolfCovariance, SampleCovariance
+from src.risk.streaming import streaming_factor_risk_matrix, streaming_sample_covariance
+
+#: Statistical estimators by name (the `RiskModel.estimate` interface).
+RISK_MODELS = {
+    "shrinkage": LedoitWolfCovariance,
+    "sample": SampleCovariance,
+}
+
+#: Every covariance model name the surfaces accept ("factor" is structural, built
+#: from exposures rather than a plain estimator).
+COVARIANCE_MODELS = (*RISK_MODELS, "factor")
+
+__all__ = [
+    "RiskMatrix",
+    "RiskModel",
+    "build_return_panel",
+    "build_risk_matrix",
+    "LedoitWolfCovariance",
+    "SampleCovariance",
+    "RISK_MODELS",
+    "COVARIANCE_MODELS",
+    "FACTOR_NAMES",
+    "build_factor_exposures",
+    "FactorRiskMatrix",
+    "estimate_factor_model",
+    "build_factor_risk_matrix",
+    "streaming_sample_covariance",
+    "streaming_factor_risk_matrix",
+]

--- a/src/risk/exposures.py
+++ b/src/risk/exposures.py
@@ -14,7 +14,7 @@ factors are on a comparable scale and the factor-return regression is well-posed
 """
 
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -32,27 +32,55 @@ def build_factor_exposures(
     momentum_skip: int = 21,
     vol_window: int = 60,
     as_of: Optional[datetime] = None,
+    factors: Optional[List[str]] = None,
+    betas: Optional[pd.Series] = None,
 ) -> pd.DataFrame:
     """Build the cross-sectionally standardized exposure matrix ``X`` (symbols × factors).
 
-    Names without enough history for every factor are dropped (the cross-section just
-    has fewer names). Returns an empty frame if fewer than two names qualify.
+    Names without enough history for every requested factor are dropped (the
+    cross-section just has fewer names). Returns an empty frame if fewer than two
+    names qualify. ``factors`` selects a subset of :data:`FACTOR_NAMES` (default:
+    all); the history requirement adapts — momentum needs the longest window, so a
+    subset without it keeps names a full build would drop. ``betas`` supplies
+    precomputed per-name betas for the market factor (a Series by symbol), skipping
+    the per-name regression when the caller already ran it.
     """
+    wanted = list(FACTOR_NAMES) if factors is None else list(factors)
+    unknown = [f for f in wanted if f not in FACTOR_NAMES]
+    if unknown:
+        raise ValueError(f"unknown factors {unknown}; available: {FACTOR_NAMES}")
+    if not wanted:
+        return pd.DataFrame()
+
+    min_bars = momentum_window + momentum_skip + 1 if "momentum" in wanted else vol_window + 1
     bench_close = benchmark_bars["close"] if benchmark_bars is not None and not benchmark_bars.empty else None
     rows: Dict[str, Dict[str, float]] = {}
     for symbol, frame in bars.items():
-        if frame is None or len(frame) < momentum_window + momentum_skip + 1:
+        if frame is None or len(frame) < min_bars:
             continue
         close = frame["close"]
-        returns = close.pct_change().dropna()
-        beta = indicators.calculate_beta(close, bench_close) if bench_close is not None else 1.0
-        momentum = close.iloc[-1 - momentum_skip] / close.iloc[-1 - momentum_skip - momentum_window] - 1.0
-        volatility = float(returns.tail(vol_window).std())
-        dollar_volume = float(close.iloc[-1] * frame["volume"].tail(vol_window).mean())
-        size = np.log(dollar_volume) if dollar_volume > 0 else np.nan
-        rows[symbol] = {"market": beta, "momentum": momentum, "volatility": volatility, "size": size}
+        row: Dict[str, float] = {}
+        if "market" in wanted:
+            known = betas.get(symbol) if betas is not None else None
+            if known is not None and known == known:  # not None, not NaN
+                row["market"] = float(known)
+            elif bench_close is not None:
+                row["market"] = indicators.calculate_beta(close, bench_close)
+            else:
+                row["market"] = 1.0
+        if "momentum" in wanted:
+            row["momentum"] = (
+                close.iloc[-1 - momentum_skip] / close.iloc[-1 - momentum_skip - momentum_window] - 1.0
+            )
+        if "volatility" in wanted:
+            returns = close.tail(vol_window + 1).pct_change().dropna()
+            row["volatility"] = float(returns.std())
+        if "size" in wanted:
+            dollar_volume = float(close.iloc[-1] * frame["volume"].tail(vol_window).mean())
+            row["size"] = np.log(dollar_volume) if dollar_volume > 0 else np.nan
+        rows[symbol] = row
 
-    frame = pd.DataFrame.from_dict(rows, orient="index").reindex(columns=FACTOR_NAMES).dropna()
+    frame = pd.DataFrame.from_dict(rows, orient="index").reindex(columns=wanted).dropna()
     if len(frame) < 2:
         return frame.iloc[0:0]
     # Cross-sectional z-score per factor (unit dispersion, mean 0).

--- a/src/risk/streaming.py
+++ b/src/risk/streaming.py
@@ -1,0 +1,214 @@
+"""Out-of-core risk estimation — stream the return panel instead of materialising it.
+
+:func:`src.risk.base.build_risk_matrix` (and the factor model that shares its
+:func:`build_return_panel`) is the only genuinely **panel-wide** (``T×N``) pandas
+materialisation in the stack: it builds an aligned returns DataFrame for the whole
+history and hands it to an estimator. For a broad universe over many years that ``T×N``
+panel is the thing that does not fit in RAM.
+
+This module is the out-of-core counterpart (spec 015): it estimates the *same*
+quantities by **streaming** the return panel out of a
+:class:`~src.data.store.ParquetBarStore` in date-chunks and accumulating sufficient
+statistics. It never holds the ``T×N`` panel: peak working memory is one chunk
+(``chunk_obs × N``) plus the small accumulators (``N×N`` / ``K×K`` / ``N``) plus a 1-D
+``O(T)`` index of complete-case timestamps — so on a long, wide history it peaks well
+below the eager path (the dominant ``T×N`` matrix is never materialised), growing in
+``T`` only as a thin timestamp vector.
+
+Two estimators, both reproducing their eager oracle to machine epsilon for the
+well-sampled names:
+
+- :func:`streaming_sample_covariance` ↔ :func:`build_risk_matrix` with
+  :class:`~src.risk.sample.SampleCovariance`.
+- :func:`streaming_factor_risk_matrix` ↔ :func:`src.risk.factor.estimate_factor_model`
+  (the structural ``Σ = X F Xᵀ + Δ``). Exposures stay a small ``N×K`` leaf computed by
+  :func:`src.risk.exposures.build_factor_exposures`.
+
+Ledoit–Wolf shrinkage needs higher moments and stays on the eager path for now — noted,
+not faked. Requires the ``store`` extra (``polars``).
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from src.marketdata.client import TimeframeLike
+from src.risk.base import RiskMatrix
+from src.risk.factor import FactorRiskMatrix
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from src.data.store import ParquetBarStore
+
+
+def _kept_and_blocks(
+    store: "ParquetBarStore",
+    universe: List[str],
+    timeframe: TimeframeLike,
+    as_of: datetime,
+    lookback_days: int,
+    min_obs: int,
+    chunk_obs: int,
+) -> Optional[Tuple[List[str], Callable[[], Iterable[np.ndarray]]]]:
+    """The shared streaming spine: the complete-case return panel, never materialised.
+
+    Reproduces :func:`build_return_panel` exactly: keep names with ≥ ``min_obs`` finite
+    returns (in ``universe`` order), take the timestamps where **every** kept name has a
+    finite return (the lazy analogue of ``returns[kept].dropna()``), and return a factory
+    that streams that complete-case panel in ``chunk_obs``-row blocks (columns in ``kept``
+    order). Returns ``(kept, blocks)`` or ``None`` if fewer than two complete-case rows.
+    """
+    import polars as pl
+
+    from src.data import compute
+
+    lf = compute.with_returns(store.scan_lazy(universe, timeframe, as_of, lookback_days), src="close")
+    # Present == finite return: mirror pandas' notna/dropna (null and NaN are missing).
+    nn = lf.filter(pl.col("ret").is_not_null() & pl.col("ret").is_not_nan())
+
+    counts = nn.group_by("symbol").agg(pl.len().alias("n")).collect(engine="streaming")
+    count_map = dict(zip(counts["symbol"].to_list(), counts["n"].to_list()))
+    kept: List[str] = []
+    seen = set()
+    for sym in universe:
+        if sym in seen:
+            continue
+        seen.add(sym)
+        if count_map.get(sym, 0) >= min_obs:
+            kept.append(sym)
+    if not kept:
+        return None
+
+    k = len(kept)
+    complete = (
+        nn.filter(pl.col("symbol").is_in(kept))
+        .group_by("ts")
+        .agg(pl.len().alias("c"))
+        .filter(pl.col("c") == k)
+        .select("ts")
+        .collect(engine="streaming")
+        .sort("ts")["ts"]
+        .to_list()
+    )
+    if len(complete) < 2:
+        return None
+
+    def blocks() -> Iterable[np.ndarray]:
+        for i in range(0, len(complete), chunk_obs):
+            ts_chunk = complete[i : i + chunk_obs]
+            block = (
+                nn.filter(pl.col("symbol").is_in(kept) & pl.col("ts").is_in(ts_chunk))
+                .select(["ts", "symbol", "ret"])
+                .collect(engine="streaming")
+                .pivot(values="ret", index="ts", on="symbol")
+                .sort("ts")
+            )
+            yield block.select(kept).to_numpy()  # rows × N, columns in kept order
+
+    return kept, blocks
+
+
+def streaming_sample_covariance(
+    store: "ParquetBarStore",
+    universe: List[str],
+    timeframe: TimeframeLike,
+    as_of: datetime,
+    *,
+    lookback_days: int = 365,
+    periods_per_year: float = 252.0,
+    min_obs: int = 60,
+    chunk_obs: int = 1024,
+) -> Optional[RiskMatrix]:
+    """Annualised sample :class:`RiskMatrix` by streaming the return panel.
+
+    Mirrors :func:`build_risk_matrix` with :class:`~src.risk.sample.SampleCovariance`
+    (population covariance), accumulating cross-products chunk-by-chunk via
+    :func:`src.data.compute.streaming_covariance`. Returns ``None`` when no name clears
+    ``min_obs`` or fewer than two complete-case rows exist; ``shrinkage`` is ``None``.
+    Kept names are returned in ``universe`` order.
+    """
+    from src.data import compute
+
+    prepared = _kept_and_blocks(store, universe, timeframe, as_of, lookback_days, min_obs, chunk_obs)
+    if prepared is None:
+        return None
+    kept, blocks = prepared
+
+    sigma_bar, n_obs = compute.streaming_covariance(blocks())
+    if n_obs < 2:
+        return None
+    return RiskMatrix(symbols=kept, sigma=sigma_bar * periods_per_year, shrinkage=None)
+
+
+def streaming_factor_risk_matrix(
+    store: "ParquetBarStore",
+    universe: List[str],
+    timeframe: TimeframeLike,
+    as_of: datetime,
+    exposures: pd.DataFrame,
+    *,
+    lookback_days: int = 365,
+    periods_per_year: float = 252.0,
+    min_obs: int = 60,
+    chunk_obs: int = 1024,
+) -> Optional[FactorRiskMatrix]:
+    """Structural factor :class:`FactorRiskMatrix` ``Σ = X F Xᵀ + Δ`` by streaming returns.
+
+    Mirrors :func:`src.risk.factor.estimate_factor_model`: factor returns are recovered
+    per period by the cross-sectional OLS ``f_t = (XᵀX)⁻¹Xᵀ r_t``, ``F`` is their
+    covariance (``ddof=1``, as ``np.cov``) and ``Δ`` the per-name residual variance
+    (``ddof=1``) — both annualised. The ``N×K`` ``exposures`` (a small cross-sectional
+    leaf from :func:`src.risk.build_factor_exposures`) stay pandas; only the panel-wide
+    ``T×N`` returns are streamed. Each chunk is projected to factor returns and residuals
+    and folded into ``K×K`` / ``N`` accumulators, so the ``T×N`` panel is never held.
+
+    Names are the well-sampled set ∩ ``exposures.index`` (the eager path's selection),
+    in ``universe`` order. Returns ``None`` if fewer than two names/periods survive.
+    """
+    prepared = _kept_and_blocks(store, universe, timeframe, as_of, lookback_days, min_obs, chunk_obs)
+    if prepared is None:
+        return None
+    kept, blocks = prepared
+
+    names = [s for s in kept if s in exposures.index]
+    if len(names) < 2:
+        return None
+    col = [kept.index(s) for s in names]  # pick the `names` columns out of each kept-ordered block
+    x = exposures.loc[names].to_numpy(dtype=float)  # N×K
+    proj = x @ np.linalg.pinv(x.T @ x)  # N×K; factor returns of a chunk R are R @ proj
+
+    n_obs = 0
+    k = x.shape[1]
+    sf = np.zeros(k)  # Σ f_t
+    sff = np.zeros((k, k))  # Σ f_t f_tᵀ
+    sr = np.zeros(len(names))  # Σ residual_t (per name)
+    srr = np.zeros(len(names))  # Σ residual_t² (per name)
+    for block in blocks():
+        r = block[:, col]  # rows × N (names columns)
+        f = r @ proj  # rows × K factor returns
+        resid = r - f @ x.T  # rows × N residuals
+        sf += f.sum(axis=0)
+        sff += f.T @ f
+        sr += resid.sum(axis=0)
+        srr += (resid * resid).sum(axis=0)
+        n_obs += r.shape[0]
+
+    if n_obs < 2:
+        return None
+    # ddof=1 sample stats from the streamed sums, to match np.cov / Series.var(ddof=1).
+    mean_f = sf / n_obs
+    factor_cov = (sff / n_obs - np.outer(mean_f, mean_f)) * (n_obs / (n_obs - 1)) * periods_per_year
+    factor_cov = np.atleast_2d(factor_cov)
+    specific_var = (srr - sr * sr / n_obs) / (n_obs - 1) * periods_per_year
+    sigma = x @ factor_cov @ x.T + np.diag(specific_var)
+
+    return FactorRiskMatrix(
+        symbols=names,
+        sigma=sigma,
+        shrinkage=None,
+        exposures=exposures.loc[names],
+        factor_cov=factor_cov,
+        specific_var=specific_var,
+        factor_names=list(exposures.columns),
+    )

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,45 @@
+"""Shared service core.
+
+Plain, side-effect-light functions that wrap the existing engine / optimizer /
+walk-forward / analytics layers and return JSON-serializable dicts. This is the
+*one* orchestration code path: the CLI (``main.py``), the MCP server
+(:mod:`src.mcp.server`), and the research agent (:mod:`src.research`) all call
+these - no business logic lives in any of those adapters.
+
+Nothing here can place an order: service functions take a
+:class:`~src.marketdata.client.MarketDataClient` (data only) and never a broker.
+"""
+
+from src.services.analysis import (
+    run_backtest,
+    run_optimization,
+    run_scan,
+    run_walk_forward,
+    summarize_bars,
+)
+from src.services.configs import list_configs, load_config, save_config
+from src.services.glossary import metrics_glossary
+from src.services.registry import (
+    SCANNERS,
+    STRATEGIES,
+    get_param_ranges,
+    list_scanners,
+    list_strategies,
+)
+
+__all__ = [
+    "STRATEGIES",
+    "SCANNERS",
+    "list_strategies",
+    "list_scanners",
+    "get_param_ranges",
+    "run_scan",
+    "run_backtest",
+    "run_optimization",
+    "run_walk_forward",
+    "summarize_bars",
+    "metrics_glossary",
+    "save_config",
+    "load_config",
+    "list_configs",
+]

--- a/src/services/analysis.py
+++ b/src/services/analysis.py
@@ -9,7 +9,7 @@ artifact file and referenced by path - never inlined.
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -24,7 +24,13 @@ from src.alphas import (
     strategy_scorer,
 )
 from src.analytics import metrics as m
-from src.data import ClientBarSource, FeaturePanel, add_risk_features, add_score_feature
+from src.data import (
+    ClientBarSource,
+    FeaturePanel,
+    add_factor_exposure_features,
+    add_risk_features,
+    add_score_feature,
+)
 from src.engine.backtest import BacktestEngine
 from src.marketdata.client import MarketDataClient
 from src.marketdata.timeframe import Timeframe
@@ -343,6 +349,7 @@ def compute_alphas(
     ic: float = DEFAULT_IC,
     benchmark: str = "SPY",
     neutralize: bool = False,
+    neutralize_factors: Sequence[str] = (),
     lookback_days: int = 180,
     timeframe: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -378,9 +385,11 @@ def compute_alphas(
 
     panel = FeaturePanel.for_universe(as_of, list(universe_bars))
     add_risk_features(panel, universe_bars, bench_frame, periods_per_year)
+    if neutralize_factors:
+        add_factor_exposure_features(panel, universe_bars, bench_frame, neutralize_factors)
     add_score_feature(panel, scorer(), universe_bars)
 
-    context = AlphaContext(ic=ic, neutralize=neutralize)
+    context = AlphaContext(ic=ic, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors))
     refine_alpha(panel, context)
     alphas = panel_to_alphas(panel, context)
 
@@ -407,6 +416,8 @@ def compute_alphas(
         "benchmark": benchmark,
         "benchmark_available": bool(panel.meta.get("benchmark_available")),
         "neutralize": neutralize,
+        "neutralize_factors": list(neutralize_factors),
+        "neutralized_against": list(panel.meta.get("neutralized_against", [])),
         "universe_size": int(panel.get("score").notna().sum()) if panel.has("score") else 0,
         "low_confidence": bool(panel.meta.get("low_confidence")),
         "alphas": _jsonable(table),
@@ -423,6 +434,7 @@ def compute_combined_alphas(
     as_of: datetime,
     benchmark: str = "SPY",
     neutralize: bool = False,
+    neutralize_factors: Sequence[str] = (),
     lookback_days: int = 365,
     timeframe: str = "1Day",
     horizon: int = 5,
@@ -464,8 +476,14 @@ def compute_combined_alphas(
     panel = FeaturePanel.for_universe(as_of, list(universe_bars))
     panel.set("score", combined_score(universe_bars, scorers, measurement, as_of))
     add_risk_features(panel, universe_bars, bench_frame, periods_per_year)
+    if neutralize_factors:
+        add_factor_exposure_features(panel, universe_bars, bench_frame, neutralize_factors)
     # The combined, measured, shrunk IC replaces the assumed scalar (no double-scaling).
-    context = AlphaContext(ic=measurement.combined_ic, neutralize=neutralize)
+    context = AlphaContext(
+        ic=measurement.combined_ic,
+        neutralize=neutralize,
+        neutralize_factors=tuple(neutralize_factors),
+    )
     refine_alpha(panel, context)
     alphas = panel_to_alphas(panel, context)
 
@@ -488,6 +506,8 @@ def compute_combined_alphas(
         "timeframe": timeframe,
         "benchmark": benchmark,
         "neutralize": neutralize,
+        "neutralize_factors": list(neutralize_factors),
+        "neutralized_against": list(panel.meta.get("neutralized_against", [])),
         "universe_size": int(panel.get("score").notna().sum()) if panel.has("score") else 0,
         "low_confidence": bool(panel.meta.get("low_confidence")),
         "n_periods": measurement.n_periods,
@@ -513,6 +533,7 @@ def compute_information(
     scanner: str = "volume",
     benchmark: str = "SPY",
     neutralize: bool = True,
+    neutralize_factors: Sequence[str] = (),
     ic_prior: float = DEFAULT_IC,
     horizon: int = 5,
     n_points: int = 24,
@@ -558,7 +579,7 @@ def compute_information(
         "signal": lambda: signal_scorer(strat),
         "scanner": lambda: scanner_scorer(_scanner(scanner)),
     }[source]()
-    ctx = AlphaContext(ic=ic_prior, neutralize=neutralize)
+    ctx = AlphaContext(ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors))
 
     index = bench.index
     lo, hi = _to_ts(start, index), _to_ts(end, index)
@@ -660,6 +681,7 @@ def compute_horizon(
     scanner: str = "volume",
     benchmark: str = "SPY",
     neutralize: bool = True,
+    neutralize_factors: Sequence[str] = (),
     ic_prior: float = DEFAULT_IC,
     max_lag: int = 10,
     n_points: int = 20,
@@ -697,7 +719,7 @@ def compute_horizon(
         "signal": lambda: signal_scorer(strat),
         "scanner": lambda: scanner_scorer(_scanner(scanner)),
     }[source]()
-    ctx = AlphaContext(ic=ic_prior, neutralize=neutralize)
+    ctx = AlphaContext(ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors))
 
     index = bench.index
     window = index[(index >= _to_ts(start, index)) & (index <= _to_ts(end, index))]
@@ -869,22 +891,31 @@ def construct_portfolio(
     max_names: Optional[int] = None,
     benchmark: str = "SPY",
     neutralize: bool = True,
+    neutralize_factors: Sequence[str] = (),
     risk_model: str = "shrinkage",
     lookback_days: int = 365,
     timeframe: str = "1Day",
     capital: Optional[float] = None,
     current_weights: Optional[Dict[str, float]] = None,
     holding_period_years: float = 1.0 / 12.0,
+    cost_aware: bool = True,
 ) -> Dict[str, Any]:
     """Construct the utility-maximising portfolio from alphas (005) and Σ (006).
 
     Read-only research-clock flow: scans the universe as of ``as_of``, builds
     benchmark-neutral alphas and an annualised covariance Σ, then maximises
-    ``αᵀw − λ·wᵀΣw`` over long-only, box-bounded, budgeted (and optionally
-    cardinality-capped) weights, calibrating ``λ`` to ``target_te``. Returns the
-    proposed weights plus the Fundamental-Law report (IR*, predicted TE/IR, transfer
-    coefficient, turnover). This is a **proposal** - it places no orders.
+    ``αᵀw − λ·wᵀΣw − cost(w − w₀)`` over long-only, box-bounded, budgeted (and
+    optionally cardinality-capped) weights, calibrating ``λ`` to ``target_te``.
+
+    With ``cost_aware`` (default) the objective carries 007's cost (Spec 016):
+    name-specific linear turnover (commission + a high-low-range spread proxy) and,
+    when ``capital`` is set, the √-impact term - so the optimiser trades a name's
+    alpha against *that name's* cost and a no-trade band emerges from the cost itself.
+    ``cost_aware=False`` recovers the cost-blind (gross) solve with an ex-post drag.
+    Returns the proposed weights plus the Fundamental-Law report (IR*, predicted TE/IR,
+    transfer coefficient, turnover, cost split). This is a **proposal** - no orders.
     """
+    from src.costs import ParametricCostModel
     from src.portfolio.optimizer import MeanVarianceOptimizer
 
     run_id = new_run_id()
@@ -907,8 +938,12 @@ def construct_portfolio(
     # Alphas (the value) and Σ (the risk denominator), both as of the same moment.
     panel = FeaturePanel.for_universe(as_of, list(universe_bars))
     add_risk_features(panel, universe_bars, bench_frame, periods_per_year)
+    if neutralize_factors:
+        add_factor_exposure_features(panel, universe_bars, bench_frame, neutralize_factors)
     add_score_feature(panel, scorer(), universe_bars)
-    alpha_ctx = AlphaContext(ic=DEFAULT_IC, neutralize=neutralize)
+    alpha_ctx = AlphaContext(
+        ic=DEFAULT_IC, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors)
+    )
     refine_alpha(panel, alpha_ctx)
     alphas = panel_to_alphas(panel, alpha_ctx)
     matrix = _build_covariance(risk_model, universe_bars, bench_frame, periods_per_year)
@@ -922,20 +957,37 @@ def construct_portfolio(
             "note": "Insufficient data for alphas and/or a covariance matrix.",
         }
 
+    cost_model = ParametricCostModel()
+    # Per-name, as-of liquidity context (spread proxy, ADV$, daily vol) priced by the
+    # same cost model the backtest uses - the optimiser and backtest share one model.
+    cost_inputs = _cost_inputs(universe_bars, cost_model) if cost_aware else None
+
     optimizer = MeanVarianceOptimizer(max_weight=max_weight, min_weight=min_weight, max_names=max_names)
-    result = optimizer.optimize(alphas, matrix, target_te=target_te, current_weights=current_weights)
+    result = optimizer.optimize(
+        alphas,
+        matrix,
+        target_te=target_te,
+        current_weights=current_weights,
+        cost_model=cost_model if cost_aware else None,
+        cost_inputs=cost_inputs,
+        capital=capital,
+        holding_period_years=holding_period_years,
+    )
 
-    # Ex-post cost drag: the proposed turnover priced through the linear cost rate,
-    # amortized over the holding period (a haircut on the expected active return).
     if result.feasible:
-        from src.costs import ParametricCostModel
-
-        rate = ParametricCostModel().turnover_cost_rate()
-        cost_drag = result.diagnostics["turnover"] * rate / max(holding_period_years, 1e-9)
-        result.diagnostics["cost_drag"] = cost_drag
-        result.diagnostics["expected_active_return_net"] = (
-            result.diagnostics["expected_active_return"] - cost_drag
-        )
+        if not result.diagnostics.get("cost_aware"):
+            # Cost-blind (gross) objective: still report the ex-post drag so the net figure
+            # is visible. Same convention as the cost-aware path - a round-trip haircut on
+            # the book for the headline (matching capacity), one-way rebalance drag in detail.
+            h = max(holding_period_years, 1e-9)
+            rate = cost_model.turnover_cost_rate()
+            expected = result.diagnostics["expected_active_return"]
+            one_way = result.diagnostics["turnover"] * rate / h
+            round_trip = 2.0 * rate * sum(result.weights.values()) / h
+            result.diagnostics["cost_drag"] = one_way
+            result.diagnostics["round_trip_cost"] = round_trip
+            result.diagnostics["expected_active_return_net"] = expected - round_trip
+            result.diagnostics["expected_active_return_net_oneway"] = expected - one_way
         # Capacity: the capital at which √-impact cost erases the gross alpha.
         result.diagnostics["capacity_capital"] = _capacity(
             result.weights, universe_bars, result.diagnostics["expected_active_return"], holding_period_years
@@ -982,6 +1034,50 @@ def construct_portfolio(
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+#: The bar feed carries no quotes, so the effective spread is proxied as this fraction
+#: of the trailing daily high-low range (a rough liquidity signal), then clamped.
+SPREAD_RANGE_FRACTION = 0.10
+_COST_WINDOW = 20  # trailing bars for the ADV / vol / spread estimates (matches the backtest)
+
+
+def _spread_proxy(frame, cost_model, window: int = _COST_WINDOW) -> float:
+    """Per-name fractional spread from the trailing high-low range, clamped.
+
+    Effective spread ≈ ``SPREAD_RANGE_FRACTION`` of the median daily range, floored at
+    a fraction of the model default (so very liquid names can price below it) and capped
+    at 2%. Falls back to the model default when OHLC is missing - an honest proxy, not a
+    quote.
+    """
+    if not {"high", "low", "close"} <= set(frame.columns) or len(frame) < 2:
+        return cost_model.default_spread
+    rng = ((frame["high"] - frame["low"]) / frame["close"]).tail(window)
+    proxy = float(rng.median()) * SPREAD_RANGE_FRACTION
+    if not np.isfinite(proxy):
+        return cost_model.default_spread
+    return float(min(max(proxy, cost_model.default_spread * 0.2), 0.02))
+
+
+def _cost_inputs(universe_bars, cost_model, window: int = _COST_WINDOW):
+    """Per-name as-of liquidity context (spread proxy, ADV$, daily vol) for the solve.
+
+    Trailing windows only, so nothing depends on post-``as_of`` bars (the same leakage
+    discipline as the backtest's cost inputs and :func:`_capacity`).
+    """
+    from src.portfolio.optimizer import CostInputs
+
+    spread, adv_dollar, daily_vol = {}, {}, {}
+    for sym, frame in universe_bars.items():
+        if frame is None or len(frame) < 2:
+            continue
+        price = float(frame["close"].iloc[-1])
+        adv_shares = float(frame["volume"].tail(window).mean()) if "volume" in frame else 0.0
+        spread[sym] = _spread_proxy(frame, cost_model, window)
+        adv_dollar[sym] = price * adv_shares
+        vol = float(frame["close"].pct_change().tail(window).std())
+        daily_vol[sym] = vol if np.isfinite(vol) else 0.0
+    return CostInputs(spread=spread, adv_dollar=adv_dollar, daily_vol=daily_vol)
+
+
 def _capacity(weights, universe_bars, gross_alpha, holding_period_years) -> float:
     """Capital at which √-impact cost erases the gross alpha (net active return → 0).
 
@@ -1074,6 +1170,8 @@ def _alpha_cross_section(universe_bars, bench, scorer, periods_per_year, t, ctx)
     bench_t = bench.loc[bench.index <= t]
     panel = FeaturePanel.for_universe(t, list(ub_t))
     add_risk_features(panel, ub_t, bench_t, periods_per_year)
+    if ctx.neutralize_factors:
+        add_factor_exposure_features(panel, ub_t, bench_t, ctx.neutralize_factors)
     add_score_feature(panel, scorer, ub_t)
     refine_alpha(panel, ctx)
     return pd.Series({a.symbol: a.alpha for a in panel_to_alphas(panel, ctx)})

--- a/tests/test_alphas.py
+++ b/tests/test_alphas.py
@@ -94,6 +94,104 @@ def test_refine_neutralize_is_beta_orthogonal():
     assert abs(float(np.dot(z.values, b.values))) < 1e-9
 
 
+def test_neutralize_multi_column_orthogonal_to_each():
+    """One regression on the exposure union: residual orthogonal to every column."""
+    rng = np.random.default_rng(7)
+    names = [f"S{i}" for i in range(20)]
+    z = pd.Series(rng.normal(size=20), index=names)
+    exposures = pd.DataFrame(
+        {"exp_volatility": rng.normal(size=20), "exp_size": rng.normal(size=20)}, index=names
+    )
+    resid = refine.neutralize(z, exposures)
+    assert abs(resid.mean()) < 1e-9
+    for col in exposures:
+        assert abs(float(np.dot(resid.values, exposures[col].values))) < 1e-9
+
+
+def test_refine_factor_neutral_is_orthogonal_to_exposure_columns():
+    """neutralize_factors regresses out exp_<factor> columns; beta may stay exposed."""
+    rng = np.random.default_rng(11)
+    raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
+    panel = _panel(raw, betas={f"S{i}": 1.0 + 0.1 * i for i in range(12)})
+    panel.set("exp_volatility", {s: float(v) for s, v in zip(raw, rng.normal(size=12))})
+    panel.set("exp_size", {s: float(v) for s, v in zip(raw, rng.normal(size=12))})
+
+    refine_alpha(panel, AlphaContext(ic=0.04, neutralize_factors=("volatility", "size")))
+    z = panel.get("z")
+    for col in ("exp_volatility", "exp_size"):
+        assert abs(float(np.dot(z.values, panel.get(col).reindex(z.index).values))) < 1e-9
+
+
+def test_refine_market_factor_supersedes_plain_beta():
+    """With 'market' in neutralize_factors, the standardized exposure column is used
+    (plain beta is skipped) and the residual is orthogonal to it."""
+    raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
+    betas = {f"S{i}": 1.0 + 0.1 * i for i in range(12)}
+    panel = _panel(raw, betas=betas)
+    exp_market = refine.zscore(pd.Series(betas))
+    panel.set("exp_market", exp_market)
+
+    refine_alpha(panel, AlphaContext(ic=0.04, neutralize=True, neutralize_factors=("market",)))
+    z = panel.get("z")
+    assert abs(float(np.dot(z.values, exp_market.reindex(z.index).values))) < 1e-9
+    # Standardized market exposure is affine in beta, so beta-orthogonality follows too.
+    assert abs(float(np.dot(z.values, pd.Series(betas).reindex(z.index).values))) < 1e-9
+
+
+def test_refine_names_missing_exposures_are_mean_imputed_not_dropped():
+    """A name missing a factor value gets the cross-sectional mean (0), staying in
+    the regression — it must not silently lose beta neutralisation (G&K union trap)."""
+    raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
+    betas = {f"S{i}": 1.0 + 0.1 * i for i in range(12)}
+    panel = _panel(raw, betas=betas)
+    covered = [s for s in list(raw) if s != "S0"]
+    rng = np.random.default_rng(3)
+    panel.set("exp_size", {s: float(v) for s, v in zip(covered, rng.normal(size=len(covered)))})
+
+    refine_alpha(panel, AlphaContext(ic=0.04, neutralize=True, neutralize_factors=("size",)))
+    z = panel.get("z")
+    b = pd.Series(betas).reindex(z.index)
+    imputed_size = panel.get("exp_size").reindex(z.index).fillna(0.0)
+    # The WHOLE cross-section (S0 included) is beta- and size-orthogonal.
+    assert abs(float(np.dot(z.values, b.values))) < 1e-9
+    assert abs(float(np.dot(z.values, imputed_size.values))) < 1e-9
+    assert panel.meta["neutralize_imputed"] == 1
+    assert panel.meta["neutralized_against"] == ["size", "beta"]
+
+
+def test_refine_unusable_exposures_fall_back_to_beta():
+    """All-NaN or constant exposure columns must degrade to beta neutralisation —
+    never to NO neutralisation (the silent-loss bug: requested market neutrality
+    on a short-history universe previously disabled beta too)."""
+    raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
+    betas = {f"S{i}": 1.0 + 0.1 * i for i in range(12)}
+    panel = _panel(raw, betas=betas)
+    panel.set("exp_market", {s: np.nan for s in raw})  # e.g. from an empty exposure build
+    panel.set("exp_volatility", {s: 1.0 for s in raw})  # constant: no cross-sectional info
+
+    refine_alpha(
+        panel,
+        AlphaContext(ic=0.04, neutralize=True, neutralize_factors=("market", "volatility")),
+    )
+    z = panel.get("z")
+    assert abs(float(np.dot(z.values, pd.Series(betas).reindex(z.index).values))) < 1e-9
+    assert panel.meta["neutralized_against"] == ["beta"]
+
+
+def test_producer_writes_nothing_on_short_history():
+    """An exposure build qualifying <2 names writes no columns, so refinement can
+    fall back to beta instead of regressing on all-NaN exposures."""
+    from src.data.features import add_factor_exposure_features
+
+    names = [f"S{i}" for i in range(12)]
+    bars = {s: make_ohlcv(n=40, seed=i, freq="1D") for i, s in enumerate(names)}  # < 61 bars
+    bench = make_ohlcv(n=40, seed=99, freq="1D")
+    panel = _panel({s: float(i % 5) - 2 for i, s in enumerate(names)})
+    add_factor_exposure_features(panel, bars, bench, ["market", "volatility", "size"])
+    assert not panel.has("exp_market")
+    assert not panel.has("exp_volatility")
+
+
 # --- scorers (the score-first migration) -------------------------------------
 def test_strategy_scorer_matches_direction():
     """A migrated strategy's score sign and discrete signal agree at a BUY bar."""
@@ -147,6 +245,31 @@ def test_alphas_are_independent_of_post_as_of_bars():
     )
     assert res_truncated["alphas"] == res_full["alphas"]
     assert res_truncated["low_confidence"] == res_full["low_confidence"]
+
+
+def test_compute_alphas_factor_neutral_end_to_end():
+    """The service threads neutralize_factors: exposures built, echoed, and applied."""
+    symbols = [f"S{i:02d}" for i in range(12)]
+    data = {s: make_ohlcv(n=250, seed=i, freq="1D") for i, s in enumerate([*symbols, "SPY"])}
+    client = MarketDataClient(DictMarketData(data))
+    as_of = data["S00"].index[-1].to_pydatetime()
+
+    plain = analysis.compute_alphas(client, "ma_crossover", symbols, as_of, benchmark="SPY")
+    neutral = analysis.compute_alphas(
+        client,
+        "ma_crossover",
+        symbols,
+        as_of,
+        benchmark="SPY",
+        neutralize_factors=("volatility", "size"),
+    )
+    assert neutral["neutralize_factors"] == ["volatility", "size"]
+    assert neutral["neutralized_against"] == ["volatility", "size"]
+    assert neutral["alphas"] and plain["alphas"]
+    # The factor regression must actually change the cross-section.
+    z_plain = {r["symbol"]: r["z"] for r in plain["alphas"]}
+    z_neutral = {r["symbol"]: r["z"] for r in neutral["alphas"]}
+    assert any(abs(z_plain[s] - z_neutral[s]) > 1e-12 for s in z_plain)
 
 
 # --- thin universe -----------------------------------------------------------

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,0 +1,464 @@
+"""Tests for lazy out-of-core compute (spec 015 — Polars · DuckDB).
+
+Skipped automatically unless the ``store`` extra (pyarrow + polars + duckdb) is
+installed. These prove the lazy ports are *faithful*: each migrated op is checked
+against its legacy pandas implementation (the equivalence oracle), plus the spec's
+cross-cutting properties — as-of pushdown, Arrow round-trip, determinism, streaming
+== eager, and bounded-memory accumulation.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pyarrow")
+pytest.importorskip("polars")
+pytest.importorskip("duckdb")
+
+import polars as pl  # noqa: E402
+
+from src.alphas import refine  # noqa: E402
+from src.data import (  # noqa: E402
+    ParquetBarStore,  # noqa: E402
+    compute,
+    edges,
+)
+from src.indicators.indicators import calculate_ema, calculate_sma  # noqa: E402
+from src.risk.sample import SampleCovariance  # noqa: E402
+from tests.fakes import make_ohlcv  # noqa: E402
+
+SYMBOLS = ["AAA", "BBB", "CCC", "DDD"]
+
+
+def _store(tmp_path, n=300):
+    bars = {s: make_ohlcv(n=n, seed=i, freq="1D") for i, s in enumerate(SYMBOLS)}
+    store = ParquetBarStore(tmp_path)
+    store.write(bars, timeframe="1Day")
+    as_of = max(b.index[-1] for b in bars.values()).to_pydatetime()
+    return store, bars, as_of
+
+
+def _series_for(frame: pl.DataFrame, symbol: str, col: str) -> np.ndarray:
+    sub = frame.filter(pl.col("symbol") == symbol).sort("ts")
+    return sub[col].to_numpy()
+
+
+# --------------------------------------------------------------------------- #
+# Time-series indicator equivalence (lazy Polars window == pandas oracle)
+# --------------------------------------------------------------------------- #
+def test_sma_matches_pandas_oracle(tmp_path):
+    store, bars, as_of = _store(tmp_path)
+    lf = compute.with_sma(store.scan_lazy(SYMBOLS, "1Day", as_of, 10_000), period=20)
+    out = edges.collect_streaming(compute.sort_canonical(lf))
+    for s in SYMBOLS:
+        oracle = calculate_sma(bars[s]["close"], 20).to_numpy()
+        np.testing.assert_allclose(_series_for(out, s, "sma"), oracle, equal_nan=True)
+
+
+def test_ema_matches_pandas_oracle(tmp_path):
+    store, bars, as_of = _store(tmp_path)
+    lf = compute.with_ema(store.scan_lazy(SYMBOLS, "1Day", as_of, 10_000), period=12)
+    out = edges.collect_streaming(compute.sort_canonical(lf))
+    for s in SYMBOLS:
+        oracle = calculate_ema(bars[s]["close"], 12).to_numpy()
+        np.testing.assert_allclose(_series_for(out, s, "ema"), oracle, equal_nan=True)
+
+
+def test_returns_match_pandas_oracle(tmp_path):
+    store, bars, as_of = _store(tmp_path)
+    lf = compute.with_returns(store.scan_lazy(SYMBOLS, "1Day", as_of, 10_000))
+    out = edges.collect_streaming(compute.sort_canonical(lf))
+    for s in SYMBOLS:
+        oracle = bars[s]["close"].pct_change().to_numpy()
+        np.testing.assert_allclose(_series_for(out, s, "ret"), oracle, equal_nan=True)
+
+
+# --------------------------------------------------------------------------- #
+# Cross-sectional refinement equivalence (lazy over("ts") == refine.py oracle)
+# --------------------------------------------------------------------------- #
+def _panel_frame(seed=0):
+    rng = np.random.default_rng(seed)
+    rows = []
+    for day in range(5):
+        for sym in SYMBOLS:
+            rows.append({"ts": day, "symbol": sym, "score": float(rng.normal())})
+    return pl.DataFrame(rows)
+
+
+def test_cross_sectional_zscore_matches_refine(tmp_path):
+    df = _panel_frame()
+    out = compute.cross_sectional_zscore(df.lazy()).collect()
+    for day in range(5):
+        got = out.filter(pl.col("ts") == day).sort("symbol")["z"].to_numpy()
+        oracle = refine.zscore(df.filter(pl.col("ts") == day).sort("symbol")["score"].to_pandas()).to_numpy()
+        np.testing.assert_allclose(got, oracle, atol=1e-12)
+
+
+def test_cross_sectional_zscore_degenerate_is_zero():
+    # A cross-section with no spread expresses no view → all zeros, not NaN (matches refine).
+    df = pl.DataFrame({"ts": [0, 0, 0], "symbol": ["A", "B", "C"], "score": [5.0, 5.0, 5.0]})
+    out = compute.cross_sectional_zscore(df.lazy()).collect()
+    assert out["z"].to_list() == [0.0, 0.0, 0.0]
+
+
+def test_cross_sectional_winsorize_matches_refine():
+    df = pl.DataFrame({"ts": [0] * 6, "symbol": list("ABCDEF"), "score": [1.0, 2, 3, 4, 5, 100]})
+    out = compute.cross_sectional_winsorize(df.lazy(), lower=0.1, upper=0.9).collect()
+    oracle = refine.winsorize(df["score"].to_pandas(), 0.1, 0.9).to_numpy()
+    np.testing.assert_allclose(out.sort("symbol")["score"].to_numpy(), oracle, atol=1e-12)
+
+
+def test_cross_sectional_rank_matches_pandas():
+    df = pl.DataFrame({"ts": [0] * 4, "symbol": list("ABCD"), "score": [3.0, 1.0, 1.0, 9.0]})
+    out = compute.cross_sectional_rank(df.lazy()).collect()
+    oracle = df["score"].to_pandas().rank().to_numpy()  # average ties, ascending
+    np.testing.assert_allclose(out.sort("symbol")["rank"].to_numpy(), oracle)
+
+
+# --------------------------------------------------------------------------- #
+# Streaming covariance (accumulated == SampleCovariance oracle, chunk-invariant)
+# --------------------------------------------------------------------------- #
+def test_streaming_covariance_matches_sample_oracle():
+    import pandas as pd
+
+    rng = np.random.default_rng(7)
+    panel = rng.normal(size=(250, 5))  # T×N return matrix
+    sigma, n = compute.streaming_covariance(compute.iter_row_chunks(panel, chunk_rows=37))
+    oracle, _ = SampleCovariance().estimate(pd.DataFrame(panel))
+    assert n == 250
+    np.testing.assert_allclose(sigma, oracle, atol=1e-12)
+
+
+def test_streaming_covariance_is_chunk_invariant():
+    rng = np.random.default_rng(11)
+    panel = rng.normal(size=(200, 4))
+    whole, _ = compute.streaming_covariance([panel])
+    for size in (1, 7, 50, 199, 1000):
+        chunked, _ = compute.streaming_covariance(compute.iter_row_chunks(panel, size))
+        np.testing.assert_allclose(chunked, whole, atol=1e-12)
+
+
+def test_streaming_covariance_bounded_memory_via_generator():
+    # The generator yields chunks lazily — the full T×N matrix never exists in memory,
+    # only one chunk plus the N×N accumulator. We assert the result still matches a
+    # reference accumulation, proving the out-of-core path is faithful.
+    import pandas as pd
+
+    N, CHUNK, NCHUNKS = 6, 64, 200  # 12,800 rows, never materialised together
+    seeds = range(NCHUNKS)
+
+    def gen():
+        for sd in seeds:
+            yield np.random.default_rng(sd).normal(size=(CHUNK, N))
+
+    sigma, n = compute.streaming_covariance(gen())
+    assert n == CHUNK * NCHUNKS
+    # Reference: same blocks concatenated once (only valid because the test is small).
+    full = np.vstack([np.random.default_rng(sd).normal(size=(CHUNK, N)) for sd in seeds])
+    oracle, _ = SampleCovariance().estimate(pd.DataFrame(full))
+    np.testing.assert_allclose(sigma, oracle, atol=1e-10)
+
+
+def test_streaming_covariance_degenerate():
+    sigma, n = compute.streaming_covariance([np.zeros((1, 3))])
+    assert n == 1
+    assert sigma.shape == (3, 3) and not sigma.any()
+
+
+# --------------------------------------------------------------------------- #
+# As-of pushdown: a lazy scan physically never reads rows after as_of
+# --------------------------------------------------------------------------- #
+def test_scan_lazy_pushes_as_of_into_parquet_scan(tmp_path):
+    store, bars, _ = _store(tmp_path)
+    cutoff = bars["AAA"].index[150]
+    lf = store.scan_lazy(SYMBOLS, "1Day", cutoff.to_pydatetime(), 10_000)
+    # The predicate is pushed into the SCAN node, not applied after materialise.
+    plan = lf.explain()
+    assert "SELECTION" in plan and "ts" in plan
+    out = edges.collect_streaming(lf)
+    assert out["ts"].max() <= cutoff.tz_convert("UTC")  # no future bar was read
+
+
+def test_scan_lazy_projection_pushdown(tmp_path):
+    store, _, as_of = _store(tmp_path)
+    lf = store.scan_lazy(SYMBOLS, "1Day", as_of, 10_000, columns=["close"])
+    out = edges.collect_streaming(lf)
+    assert set(out.columns) == {"ts", "symbol", "close"}  # only projected columns read
+
+
+def test_scan_lazy_empty_universe_is_empty(tmp_path):
+    store, _, as_of = _store(tmp_path)
+    lf = store.scan_lazy(["NOPE"], "1Day", as_of, 10_000)
+    assert edges.collect_streaming(lf).is_empty()
+
+
+# --------------------------------------------------------------------------- #
+# Arrow round-trip: provider → store → polars → pandas edge preserves everything
+# --------------------------------------------------------------------------- #
+def test_arrow_roundtrip_preserves_values_dtypes_tz_order(tmp_path):
+    store, bars, as_of = _store(tmp_path)
+    lf = store.scan_lazy(["AAA"], "1Day", as_of, 10_000)
+    pdf = edges.to_pandas(compute.sort_canonical(lf), index="ts")
+
+    original = bars["AAA"]
+    assert str(pdf.index.tz) == "UTC"  # tz-aware UTC survived the crossing
+    assert pdf.index.is_monotonic_increasing  # order preserved
+    np.testing.assert_allclose(pdf["close"].to_numpy(), original["close"].to_numpy())
+    for col in ("open", "high", "low", "close", "volume"):
+        assert pdf[col].dtype == np.float64  # no float64 → object demotion
+
+
+def test_from_pandas_edge_roundtrips():
+    store_pdf = make_ohlcv(n=20, seed=0, freq="1D")
+    store_pdf.index.name = "ts"  # name the index so it survives as a named column
+    back = edges.to_pandas(edges.from_pandas(store_pdf, include_index=True), index="ts")
+    np.testing.assert_allclose(back["close"].to_numpy(), store_pdf["close"].to_numpy())
+
+
+# --------------------------------------------------------------------------- #
+# Determinism + streaming == eager
+# --------------------------------------------------------------------------- #
+def test_streaming_equals_eager_collect(tmp_path):
+    # Same plan, two engines (streaming vs in-memory). Row order and ints/strings are
+    # identical; float reductions can differ at machine epsilon by reduction order, so
+    # the numeric columns are compared within tolerance (byte-identity is the
+    # *same-engine repeated-run* property, asserted separately below).
+    store, _, as_of = _store(tmp_path)
+    lf = compute.sort_canonical(
+        compute.cross_sectional_zscore(
+            compute.with_returns(store.scan_lazy(SYMBOLS, "1Day", as_of, 10_000)),
+            src="ret",
+        )
+    )
+    streamed = edges.collect_streaming(lf)
+    eager = lf.collect()
+    assert streamed["symbol"].equals(eager["symbol"])
+    assert streamed["ts"].equals(eager["ts"])
+    for col in ("ret", "z"):
+        np.testing.assert_allclose(
+            streamed[col].to_numpy(), eager[col].to_numpy(), rtol=1e-12, atol=1e-12, equal_nan=True
+        )
+
+
+def test_deterministic_across_repeated_runs(tmp_path):
+    store, _, as_of = _store(tmp_path)
+    lf = compute.sort_canonical(compute.with_sma(store.scan_lazy(SYMBOLS, "1Day", as_of, 10_000), 10))
+    first = edges.collect_streaming(lf)
+    for _ in range(3):
+        assert edges.collect_streaming(lf).equals(first)  # byte-identical run to run
+
+
+# --------------------------------------------------------------------------- #
+# DuckDB set-based path over the Parquet store
+# --------------------------------------------------------------------------- #
+def test_sql_query_aggregation_matches_pandas(tmp_path):
+    store, bars, _ = _store(tmp_path)
+    paths = store.partition_paths(SYMBOLS, "1Day")
+    got = compute.sql_query(
+        paths, "SELECT symbol, count(*) AS n, avg(close) AS m FROM bars GROUP BY symbol ORDER BY symbol"
+    )
+    got_pd = edges.to_pandas(got, index="symbol")
+    for s in SYMBOLS:
+        assert int(got_pd.loc[s, "n"]) == len(bars[s])
+        assert got_pd.loc[s, "m"] == pytest.approx(float(bars[s]["close"].mean()))
+
+
+def test_sql_query_as_of_param_pushdown(tmp_path):
+    store, bars, _ = _store(tmp_path)
+    paths = store.partition_paths(["AAA"], "1Day")
+    cutoff = bars["AAA"].index[100].tz_convert("UTC").to_pydatetime()
+    got = compute.sql_query(
+        paths, "SELECT count(*) AS n, max(ts) AS last FROM bars WHERE ts <= ?", params=[cutoff]
+    )
+    assert got["last"][0] <= cutoff  # the point-in-time cutoff held inside the scan
+
+
+def test_sql_query_empty_result_has_schema(tmp_path):
+    store, _, _ = _store(tmp_path)
+    paths = store.partition_paths(["AAA"], "1Day")
+    got = compute.sql_query(paths, "SELECT * FROM bars WHERE close < -1")  # matches nothing
+    assert got.height == 0 and "close" in got.columns
+
+
+# --------------------------------------------------------------------------- #
+# Regression tests for the spec-015 adversarial review.
+# Each guards a confirmed finding the original suite missed.
+# --------------------------------------------------------------------------- #
+def _shuffled_store(tmp_path, n=40, seed=3):
+    # A single symbol whose bars are written OUT of ts order on disk (write does not
+    # sort), to prove the lazy window helpers no longer trust physical row order.
+    import pandas as pd
+
+    idx = pd.date_range("2024-01-02", periods=n, freq="1D", tz="UTC")
+    close = np.arange(n, dtype=float) + 10
+    frame = pd.DataFrame({c: close for c in ("open", "high", "low", "close", "volume")}, index=idx)
+    store = ParquetBarStore(tmp_path)
+    store.write({"AAA": frame.sample(frac=1.0, random_state=seed)}, timeframe="1Day")
+    return store, frame, idx[-1].to_pydatetime()
+
+
+def test_indicators_correct_on_unsorted_partition(tmp_path):
+    # Finding lazy-window-unsorted-ts / indicators-no-ts-sort: rolling/ewm/returns must
+    # match the ts-sorted pandas oracle even when the partition is shuffled on disk.
+    store, frame, as_of = _shuffled_store(tmp_path)
+    lf = store.scan_lazy(["AAA"], "1Day", as_of, 10_000)
+    lf = compute.with_returns(compute.with_ema(compute.with_sma(lf, 5), 12))
+    out = edges.collect_streaming(compute.sort_canonical(lf))
+    np.testing.assert_allclose(
+        out["sma"].to_numpy(), calculate_sma(frame["close"], 5).to_numpy(), equal_nan=True
+    )
+    np.testing.assert_allclose(
+        out["ema"].to_numpy(), calculate_ema(frame["close"], 12).to_numpy(), equal_nan=True
+    )
+    np.testing.assert_allclose(out["ret"].to_numpy(), frame["close"].pct_change().to_numpy(), equal_nan=True)
+
+
+def _xs(scores):
+    """A one-timestamp cross-section panel from a list of (possibly non-finite) scores."""
+    syms = [f"S{i}" for i in range(len(scores))]
+    return pl.DataFrame({"ts": [0] * len(scores), "symbol": syms, "score": [float(s) for s in scores]})
+
+
+def test_zscore_nan_does_not_poison_cross_section():
+    # Finding zscore-nan-poisons-cross-section: one NaN must not zero the whole bar.
+    import pandas as pd
+
+    df = _xs([1.0, 2.0, float("nan"), 4.0])
+    got = compute.cross_sectional_zscore(df.lazy()).collect().sort("symbol")["z"].to_numpy()
+    oracle = refine.zscore(pd.Series([1.0, 2.0, np.nan, 4.0])).to_numpy()
+    np.testing.assert_allclose(got, oracle, atol=1e-12, equal_nan=True)
+
+
+def test_zscore_inf_treated_as_missing():
+    import pandas as pd
+
+    df = _xs([1.0, float("inf"), 3.0])
+    got = compute.cross_sectional_zscore(df.lazy()).collect().sort("symbol")["z"].to_numpy()
+    # inf -> missing, the two finite names standardise around their own mean/std.
+    oracle = refine.zscore(pd.Series([1.0, np.nan, 3.0])).to_numpy()
+    np.testing.assert_allclose(got, oracle, atol=1e-12, equal_nan=True)
+
+
+def test_rank_nan_stays_missing_not_top():
+    # Finding rank-treats-nan-as-largest: a NaN must not be handed a tradable rank.
+    import pandas as pd
+
+    df = _xs([3.0, float("nan"), 1.0, 1.0, 9.0])
+    got = compute.cross_sectional_rank(df.lazy()).collect().sort("symbol")["rank"].to_numpy()
+    oracle = pd.Series([3.0, np.nan, 1.0, 1.0, 9.0]).rank().to_numpy()
+    np.testing.assert_allclose(got, oracle, equal_nan=True)
+
+
+def test_winsorize_skips_nan_like_oracle():
+    import pandas as pd
+
+    vals = [1.0, 2.0, float("nan"), 4.0, 5.0, 100.0]
+    df = _xs(vals)
+    got = compute.cross_sectional_winsorize(df.lazy(), lower=0.1, upper=0.9).collect().sort("symbol")["score"]
+    oracle = refine.winsorize(pd.Series(vals), 0.1, 0.9).to_numpy()
+    np.testing.assert_allclose(got.to_numpy(), oracle, atol=1e-12, equal_nan=True)
+
+
+def test_demean_matches_refine_including_nan():
+    # cross_sectional_demean had no test at all (coverage gap) and must skip non-finite.
+    import pandas as pd
+
+    for vals in ([1.0, 2.0, 3.0, 6.0], [1.0, float("nan"), 3.0]):
+        df = _xs(vals)
+        got = compute.cross_sectional_demean(df.lazy()).collect().sort("symbol")["z"].to_numpy()
+        oracle = refine.demean(pd.Series(vals)).to_numpy()
+        np.testing.assert_allclose(got, oracle, atol=1e-12, equal_nan=True)
+
+
+def test_returns_then_zscore_survives_zero_price():
+    # End-to-end: a 0/0 return is a real NaN; it must not flatten the rest of the bar.
+    import pandas as pd
+
+    # Three symbols at two timestamps; symbol B has a flat-zero price → NaN return at t1.
+    rows = []
+    closes = {"A": [10.0, 11.0], "B": [0.0, 0.0], "C": [10.0, 15.0]}
+    ts = pd.date_range("2024-01-01", periods=2, freq="D", tz="UTC")
+    for sym, cs in closes.items():
+        for t, c in zip(ts, cs):
+            rows.append({"ts": t, "symbol": sym, "close": c})
+    df = pl.DataFrame(rows)
+    lf = compute.cross_sectional_zscore(compute.with_returns(df.lazy(), src="close"), src="ret", by="ts")
+    out = edges.collect_streaming(compute.sort_canonical(lf)).filter(pl.col("ts") == ts[1]).sort("symbol")
+    z = out["z"].to_list()
+    # A and C have real, differing returns → a real long/short view; B (NaN) stays null.
+    assert z[0] is not None and z[2] is not None and z[0] != z[2]
+    assert z[1] is None
+
+
+def test_scan_lazy_naive_as_of_localises_utc(tmp_path):
+    # Finding coverage gap: a naive (tz-less) as_of must behave like the eager scan().
+    import datetime as dt
+
+    store, bars, _ = _store(tmp_path)
+    naive = bars["AAA"].index[100].tz_convert("UTC").tz_localize(None).to_pydatetime()
+    assert naive.tzinfo is None
+    lazy_rows = edges.collect_streaming(store.scan_lazy(["AAA"], "1Day", naive, 10_000)).height
+    eager_rows = len(store.scan(["AAA"], "1Day", naive, 10_000)["AAA"])
+    assert lazy_rows == eager_rows  # lazy and eager agree on the localised window
+
+    # And a non-UTC tz-aware as_of resolves to the same instant.
+    ny = bars["AAA"].index[100].tz_convert("America/New_York").to_pydatetime()
+    assert isinstance(ny, dt.datetime) and ny.tzinfo is not None
+    assert edges.collect_streaming(store.scan_lazy(["AAA"], "1Day", ny, 10_000)).height == eager_rows
+
+
+def test_scan_lazy_window_matches_eager_scan(tmp_path):
+    # The lazy and eager BarSource paths must return identical row sets (same window).
+    store, bars, _ = _store(tmp_path)
+    cutoff = bars["AAA"].index[150]
+    as_of = cutoff.to_pydatetime()
+    lazy = edges.collect_streaming(store.scan_lazy(["AAA"], "1Day", as_of, 90)).sort("ts")
+    eager = store.scan(["AAA"], "1Day", as_of, 90)["AAA"]
+    assert lazy.height == len(eager)
+    np.testing.assert_allclose(lazy["close"].to_numpy(), eager["close"].to_numpy())
+
+
+def test_scan_lazy_empty_universe_supports_pipeline(tmp_path):
+    # Finding lazy-empty-universe-no-schema: a window helper on an empty-universe scan
+    # must yield an empty (correctly-columned) frame, not ColumnNotFoundError.
+    store, _, as_of = _store(tmp_path)
+    lf = compute.with_returns(store.scan_lazy(["NOPE"], "1Day", as_of, 10_000))
+    out = edges.collect_streaming(lf)
+    assert out.is_empty() and {"ts", "symbol", "close", "ret"} <= set(out.columns)
+
+
+def test_from_pandas_unnamed_datetime_index_becomes_ts():
+    # Finding from-pandas-unnamed-index-string-None: an unnamed DatetimeIndex must
+    # cross as a real `ts` column, not the string "None".
+    df = make_ohlcv(n=8, seed=0, freq="1D")  # index.name is None
+    assert df.index.name is None
+    lifted = edges.from_pandas(df, include_index=True)
+    assert "ts" in lifted.columns and "None" not in lifted.columns
+    back = edges.to_pandas(lifted, index="ts")
+    np.testing.assert_allclose(back["close"].to_numpy(), df["close"].to_numpy())
+
+
+def test_to_pandas_missing_index_raises_clear_error():
+    with pytest.raises(KeyError, match="not in frame"):
+        edges.to_pandas(pl.DataFrame({"a": [1]}), index="ts")
+
+
+def test_streaming_covariance_bounded_memory_tracemalloc():
+    # Finding no-bounded-memory-test: the accumulator's peak memory must be bounded by
+    # one chunk + the N×N accumulator, NOT by total history. Feed a generator so the
+    # full T×N panel never exists, and assert peak allocation stays near chunk-size.
+    import tracemalloc
+
+    N, CHUNK, NCHUNKS = 8, 256, 400  # 102,400 rows would be ~6.5 MB if materialised
+    full_bytes = N * CHUNK * NCHUNKS * 8
+
+    def gen():
+        for sd in range(NCHUNKS):
+            yield np.random.default_rng(sd).normal(size=(CHUNK, N))
+
+    tracemalloc.start()
+    _, n = compute.streaming_covariance(gen())
+    peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+    assert n == CHUNK * NCHUNKS
+    # Peak should be a small multiple of one chunk, far below the full panel.
+    assert peak < full_bytes // 4

--- a/tests/test_cost_aware.py
+++ b/tests/test_cost_aware.py
@@ -1,0 +1,545 @@
+"""Tests for cost-aware portfolio construction (spec 016).
+
+Cost is inside the objective: ``αᵀw − λ·wᵀΣw − Σ cᵢ|Δwᵢ| − Σ kᵢ|Δwᵢ|^{3/2}``. These
+tests cover the spec §6 checklist — name-specific tilt, the emergent no-trade band,
+w₀ sensitivity, √-impact super-linearity, the linear↔conic gap, and the zero-cost
+reduction to spec 008 — plus the proximal-operator primitives, a KKT optimality
+certificate, the cost-model coefficients, and the end-to-end service integration.
+
+Offline and deterministic.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from src.alphas.base import Alpha
+from src.costs import ParametricCostModel
+from src.costs.base import CostModel, Trade
+from src.marketdata.client import MarketDataClient
+from src.portfolio.optimizer import CostInputs, MeanVarianceOptimizer
+from src.risk.base import RiskMatrix
+from tests.fakes import DictMarketData, make_ohlcv
+
+AS_OF = datetime(2024, 6, 1)
+SYMS = ["A", "B", "C", "D"]
+_L = np.array([[0.20, 0, 0, 0], [0.05, 0.18, 0, 0], [0.03, 0.04, 0.22, 0], [0.01, 0.02, 0.03, 0.16]])
+SIGMA = _L @ _L.T
+ALPHA = np.array([0.06, 0.02, -0.01, 0.04])
+LAM = 2.0
+H = 1.0 / 12.0
+
+
+def _alphas(bump: float = 0.0) -> list:
+    return [Alpha(s, float(ALPHA[i]) + bump, AS_OF, 0.2, 0.05, 0.0) for i, s in enumerate(SYMS)]
+
+
+def _risk() -> RiskMatrix:
+    return RiskMatrix(SYMS, SIGMA)
+
+
+def _vec(result) -> np.ndarray:
+    return np.array([result.weights.get(s, 0.0) for s in SYMS])
+
+
+def _inputs(spread, adv_dollar=1e12, daily_vol=0.02) -> CostInputs:
+    """A CostInputs with a uniform (or per-name dict) spread and deep default liquidity."""
+    sp = spread if isinstance(spread, dict) else {s: spread for s in SYMS}
+    return CostInputs(
+        spread=sp,
+        adv_dollar={s: adv_dollar for s in SYMS},
+        daily_vol={s: daily_vol for s in SYMS},
+    )
+
+
+# --- closed-form / zero-cost reduction (spec §6 "closed-form sanity") --------
+def test_zero_cost_reduces_to_cost_blind_solve():
+    free = ParametricCostModel(commission_bps=0.0, default_spread_bps=0.0)
+    blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
+    zero = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=free,
+        cost_inputs=_inputs(0.0),
+        holding_period_years=H,
+    )
+    assert np.allclose(_vec(zero), _vec(blind), atol=1e-9)
+    # Unconstrained optimum still the spec-008 closed form, untouched by the (zero) cost.
+    expected = (np.linalg.inv(SIGMA) @ ALPHA) / (2 * LAM)
+    got = np.array([blind.unconstrained_weights[s] for s in SYMS])
+    assert np.allclose(got, expected)
+
+
+# --- name-specific cost changes weights (spec §6 test 1) ---------------------
+def test_uniform_cost_from_cash_is_a_noop():
+    # Long-only from cash with a uniform per-name cost: Σcᵢ|wᵢ| = c·Σwᵢ = c is constant,
+    # so the optimum is unchanged — the baseline the name-specific case must beat.
+    model = ParametricCostModel()
+    blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
+    uniform = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=_inputs(0.001),
+        holding_period_years=H,
+    )
+    assert np.allclose(_vec(uniform), _vec(blind), atol=1e-6)
+
+
+def test_name_specific_cost_tilts_away_from_expensive_names():
+    model = ParametricCostModel()
+    blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
+    # Make the top-alpha name (A) expensive; the cost-aware optimum must down-weight it.
+    expensive = {"A": 0.02, "B": 0.0005, "C": 0.0005, "D": 0.0005}
+    tilted = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=_inputs(expensive),
+        holding_period_years=H,
+    )
+    assert _vec(tilted)[0] < _vec(blind)[0] - 1e-6  # A shrinks
+    assert abs(sum(tilted.weights.values()) - 1.0) < 1e-6  # still fully invested
+
+
+# --- emergent no-trade band (spec §6 test 2) ---------------------------------
+def test_emergent_no_trade_band_suppresses_subthreshold_churn():
+    model = ParametricCostModel()
+    opt = MeanVarianceOptimizer(max_weight=0.5)  # no_trade_band=0: the band must EMERGE from cost
+    base = opt.optimize(_alphas(), _risk(), risk_aversion=LAM)
+    # Nudge one name's alpha by +0.02 — below its cost band (a ~100bps spread over a 1/12
+    # yr hold gives a ~6%/yr band half-width), but enough that a cost-blind solve chases it.
+    nudged = [
+        Alpha(s, float(ALPHA[i]) + (0.02 if s == "D" else 0.0), AS_OF, 0.2, 0.05, 0.0)
+        for i, s in enumerate(SYMS)
+    ]
+    rebal = opt.optimize(
+        nudged,
+        _risk(),
+        risk_aversion=LAM,
+        current_weights=base.weights,
+        cost_model=model,
+        cost_inputs=_inputs(0.01),
+        holding_period_years=H,
+    )
+    assert rebal.diagnostics["turnover"] < 1e-9  # machine epsilon: no meaningful trade
+    assert rebal.diagnostics["names_traded"] == 0
+    # Without the cost, the same nudge chases the alpha — the band is doing the work.
+    chase = opt.optimize(nudged, _risk(), risk_aversion=LAM, current_weights=base.weights)
+    assert chase.diagnostics["turnover"] > 1e-3
+
+
+def test_no_trade_band_half_width_is_the_one_way_cost():
+    # The band edge is the soft-threshold in _prox_step: no trade iff |m| ≤ thr, where
+    # thr = one-way cost cᵢ. Full band width (buy edge − sell edge) = 2cᵢ = round trip.
+    m = np.array([-0.05, -0.011, -0.009, 0.009, 0.011, 0.05])
+    thr = np.full_like(m, 0.01)
+    d = MeanVarianceOptimizer._prox_step(m, thr, np.zeros_like(m))
+    assert list(np.abs(d) > 0) == [True, True, False, False, True, True]  # zero strictly inside ±thr
+
+    model = ParametricCostModel(commission_bps=1.0, default_spread_bps=5.0)
+    c_one_way = model.turnover_cost_rate() / H  # cᵢ, annualised one-way
+    c_lin, _ = MeanVarianceOptimizer._cost_coefficients(model, _inputs(model.default_spread), None, H, SYMS)
+    assert np.allclose(c_lin, c_one_way)
+    # Full band width = 2·cᵢ equals the annualised round-trip rate (impact→0 for a tiny trade).
+    tiny = Trade("A", shares=1e-6, price=100.0, adv=1e12, daily_vol=0.02, spread=model.default_spread)
+    assert 2 * c_one_way == pytest.approx(model.annual_cost_rate(tiny, H), rel=1e-6)
+
+
+# --- w0 sensitivity (spec §6 test 3) -----------------------------------------
+def test_turnover_depends_on_current_weights():
+    model = ParametricCostModel()
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    kw = dict(cost_model=model, cost_inputs=_inputs(0.0005), holding_period_years=H)
+    target = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, **kw)
+    from_target = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, current_weights=target.weights, **kw)
+    from_cash = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, current_weights={}, **kw)
+    assert from_target.diagnostics["turnover"] < 1e-6  # already optimal → no trade
+    assert from_cash.diagnostics["turnover"] > 0.5  # from cash → fully invest
+
+
+# --- √-impact super-linearity (spec §6 test 4) -------------------------------
+def test_impact_penalty_is_superlinear_in_trade_size():
+    # The penalty kᵢ·|Δw|^{3/2} under the optimiser's *own* coefficient: doubling the
+    # trade more than doubles it (×2^1.5). Uses the real _cost_coefficients so an
+    # annualisation/formula bug in kᵢ would surface here, not just literal arithmetic.
+    model = ParametricCostModel()
+    _, k_imp = MeanVarianceOptimizer._cost_coefficients(model, _inputs(0.0005, adv_dollar=1e8), 1e7, H, SYMS)
+    assert np.all(k_imp > 0)
+    p1 = k_imp[0] * 0.1**1.5
+    p2 = k_imp[0] * 0.2**1.5
+    assert p2 / p1 == pytest.approx(2**1.5)
+
+
+def test_sqrt_impact_spreads_size_away_from_illiquid_names():
+    model = ParametricCostModel()
+    # A (top alpha) is illiquid; the rest are deep. Impact should pull size off A.
+    adv = {"A": 5e6, "B": 5e11, "C": 5e11, "D": 5e11}
+    ci = CostInputs(spread={s: 0.0005 for s in SYMS}, adv_dollar=adv, daily_vol={s: 0.03 for s in SYMS})
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    linear = opt.optimize(  # capital=None → linear only, no √-impact
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
+    conic = opt.optimize(  # capital set → √-impact active
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=5e7,
+        holding_period_years=H,
+    )
+    assert conic.diagnostics["impact_cost"] > 0
+    assert _vec(conic)[0] < _vec(linear)[0] - 1e-4  # A down-weighted by impact
+    assert abs(sum(conic.weights.values()) - 1.0) < 1e-6
+
+
+# --- linear ↔ conic gap (spec §6 test 5) -------------------------------------
+def test_linear_and_conic_agree_when_impact_is_negligible_and_gap_is_reported():
+    model = ParametricCostModel()
+    ci = _inputs(0.0005, adv_dollar=1e13)  # very deep books
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    linear = opt.optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
+    conic = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=1e5,
+        holding_period_years=H,
+    )
+    # Deep liquidity + small capital → the √-impact term is tiny, so the two solutions
+    # coincide within tolerance; the impact charge is surfaced, not hidden.
+    assert np.max(np.abs(_vec(linear) - _vec(conic))) < 1e-3
+    assert "impact_cost" in conic.diagnostics
+    assert conic.diagnostics["impact_cost"] < 1e-4
+
+
+def test_conic_gap_grows_with_capital():
+    model = ParametricCostModel()
+    ci = _inputs(0.0005, adv_dollar=1e8)
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    small = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=1e5,
+        holding_period_years=H,
+    )
+    large = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=1e9,
+        holding_period_years=H,
+    )
+    assert large.diagnostics["impact_cost"] > small.diagnostics["impact_cost"]
+
+
+# --- KKT optimality certificate ----------------------------------------------
+def test_no_feasible_perturbation_beats_the_cost_aware_optimum():
+    model = ParametricCostModel()
+    ci = _inputs({"A": 0.02, "B": 0.0005, "C": 0.0005, "D": 0.0005})
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    res = opt.optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
+    w = _vec(res)
+    c_lin, k_imp = MeanVarianceOptimizer._cost_coefficients(model, ci, None, H, SYMS)
+    w0 = np.zeros(4)
+
+    def util(x):
+        dw = x - w0
+        return (
+            ALPHA @ x - LAM * (x @ SIGMA @ x) - np.sum(c_lin * np.abs(dw)) - np.sum(k_imp * np.abs(dw) ** 1.5)
+        )
+
+    u_opt = util(w)
+    rng = np.random.default_rng(0)
+    beats = 0
+    for _ in range(5000):
+        i, j = rng.integers(0, 4, 2)
+        eps = rng.uniform(0, 0.02)
+        wp = w.copy()
+        wp[i] += eps
+        wp[j] -= eps  # budget-preserving swap
+        if wp[i] <= 0.5 + 1e-12 and wp[j] >= -1e-12 and util(wp) > u_opt + 1e-8:
+            beats += 1
+    assert beats == 0
+
+
+# --- proximal-operator primitive ---------------------------------------------
+def test_prox_step_matches_brute_force_minimizer():
+    grid = np.linspace(-0.6, 0.6, 24001)
+    for m, thr, kthr in [(0.3, 0.05, 0.0), (0.3, 0.05, 0.4), (-0.25, 0.02, 0.7), (0.01, 0.05, 0.4)]:
+        obj = 0.5 * (grid - m) ** 2 + thr * np.abs(grid) + kthr * np.abs(grid) ** 1.5
+        brute = grid[int(np.argmin(obj))]
+        closed = float(MeanVarianceOptimizer._prox_step(np.array([m]), np.array([thr]), np.array([kthr]))[0])
+        assert abs(closed - brute) < 1e-3
+
+
+def test_prox_step_reduces_to_soft_threshold_without_impact():
+    m = np.array([-0.3, -0.02, 0.0, 0.02, 0.3])
+    thr = np.full_like(m, 0.05)
+    got = MeanVarianceOptimizer._prox_step(m, thr, np.zeros_like(m))
+    expected = np.sign(m) * np.maximum(np.abs(m) - thr, 0.0)
+    assert np.allclose(got, expected)
+
+
+# --- cost-model coefficients -------------------------------------------------
+def test_impact_coefficient_formula_and_missing_data():
+    model = ParametricCostModel(impact_eta=0.3)
+    assert model.impact_coefficient(0.02, adv_dollar=1e8, capital=1e6) == pytest.approx(
+        0.3 * 0.02 * np.sqrt(1e6 / 1e8)
+    )
+    assert model.impact_coefficient(0.02, adv_dollar=0.0, capital=1e6) == 0.0  # no ADV → no impact
+    assert model.impact_coefficient(0.02, adv_dollar=1e8, capital=0.0) == 0.0  # no capital → no impact
+    assert ParametricCostModel(linear_impact=True).impact_coefficient(0.02, 1e8, 1e6) == 0.0
+
+
+def test_base_cost_model_has_zero_cost_defaults():
+    class Null(CostModel):
+        def cost(self, trade):  # pragma: no cover - trivial
+            from src.costs.base import TradeCost
+
+            return TradeCost(0, 0, 0, 0, capped=False)
+
+    null = Null()
+    assert null.turnover_cost_rate() == 0.0
+    assert null.impact_coefficient(0.02, 1e8, 1e6) == 0.0
+
+
+# --- spread proxy ------------------------------------------------------------
+def test_spread_proxy_is_monotone_in_range_and_clamped():
+    from src.services.analysis import _spread_proxy
+
+    model = ParametricCostModel()
+    tight = make_ohlcv(n=60, seed=1, freq="1D")
+    wide = tight.assign(high=tight["high"] * 1.5, low=tight["low"] * 0.5)  # a much wider range
+    assert _spread_proxy(wide, model) >= _spread_proxy(tight, model)
+    assert _spread_proxy(wide, model) <= 0.02  # capped
+    assert _spread_proxy(tight, model) >= model.default_spread * 0.2  # floored
+    # No OHLC → the model default.
+    import pandas as pd
+
+    assert _spread_proxy(pd.DataFrame({"close": [1.0, 2.0]}), model) == model.default_spread
+
+
+# --- service integration -----------------------------------------------------
+def _universe():
+    symbols = [f"S{i}" for i in range(8)]
+    bars = {s: make_ohlcv(n=300, seed=i, freq="1D") for i, s in enumerate([*symbols, "SPY"])}
+    return symbols, MarketDataClient(DictMarketData(bars))
+
+
+def test_construct_portfolio_cost_aware_reports_the_cost_split():
+    from src.services import analysis
+
+    symbols, dc = _universe()
+    res = analysis.construct_portfolio(
+        dc, "ma_crossover", symbols, AS_OF, capital=1_000_000.0, cost_aware=True
+    )
+    if not res["feasible"]:
+        pytest.skip("fixture produced no feasible portfolio")
+    d = res["diagnostics"]
+    assert d.get("cost_aware") is True
+    assert "linear_cost" in d and "impact_cost" in d
+    # Headline net is the round-trip haircut; the one-way rebalance figure stays in detail.
+    assert d["expected_active_return_net"] == pytest.approx(
+        d["expected_active_return"] - d["round_trip_cost"]
+    )
+    assert d["expected_active_return_net_oneway"] == pytest.approx(
+        d["expected_active_return"] - d["cost_drag"]
+    )
+    assert d["cost_drag"] == pytest.approx(d["linear_cost"] + d["impact_cost"])  # one-way total
+
+
+def test_construct_portfolio_gross_objective_uses_ex_post_drag():
+    from src.services import analysis
+
+    symbols, dc = _universe()
+    res = analysis.construct_portfolio(
+        dc, "ma_crossover", symbols, AS_OF, capital=1_000_000.0, cost_aware=False
+    )
+    if not res["feasible"]:
+        pytest.skip("fixture produced no feasible portfolio")
+    d = res["diagnostics"]
+    assert not d.get("cost_aware")
+    assert "cost_drag" in d  # ex-post drag still reported on the cost-blind solve
+
+
+# --- reported-value integrity ------------------------------------------------
+def test_reported_linear_cost_equals_independent_sum():
+    # Pin the diagnostic against an independently computed Σ cᵢ|Δwᵢ| (from cash, w₀=0),
+    # so a coefficient or annualisation bug surfaces (not just the net = gross − cost id).
+    model = ParametricCostModel()
+    ci = _inputs({"A": 0.02, "B": 0.001, "C": 0.0005, "D": 0.0005})
+    res = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
+    w = _vec(res)
+    c_lin, _ = MeanVarianceOptimizer._cost_coefficients(model, ci, None, H, SYMS)
+    assert res.diagnostics["linear_cost"] == pytest.approx(float(np.sum(c_lin * np.abs(w))))
+
+
+# --- round-trip headline haircut --------------------------------------------
+def test_round_trip_headline_is_conservative_and_capacity_aligned():
+    model = ParametricCostModel()
+    ci = _inputs({"A": 0.02, "B": 0.001, "C": 0.0005, "D": 0.0005}, adv_dollar=1e8)
+    res = MeanVarianceOptimizer(max_weight=0.5).optimize(  # from cash → Δw = w
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=1e7,
+        holding_period_years=H,
+    )
+    d = res.diagnostics
+    w = _vec(res)
+    c_lin, k_imp = MeanVarianceOptimizer._cost_coefficients(model, ci, 1e7, H, SYMS)
+    # Round-trip = 2 × (Σ cᵢwᵢ + Σ kᵢwᵢ^{3/2}) — the same book cost capacity prices, ×2.
+    expected_rt = 2.0 * (float(np.sum(c_lin * w)) + float(np.sum(k_imp * w**1.5)))
+    assert d["round_trip_cost"] == pytest.approx(expected_rt)
+    # From cash the round-trip is exactly twice the one-way rebalance cost, and strictly
+    # more conservative than the one-way net.
+    assert d["round_trip_cost"] == pytest.approx(2.0 * d["cost_drag"])
+    assert d["expected_active_return_net"] < d["expected_active_return_net_oneway"]
+    assert d["expected_active_return_net"] == pytest.approx(d["expected_active_return"] - expected_rt)
+
+
+# --- cardinality / dust re-solve with cost (spec §4 factor 6 interaction) ----
+def test_cardinality_liquidation_cost_is_counted():
+    # A full-book w₀ with max_names=2 must fully liquidate the dropped names; that
+    # liquidation turnover and its cost must appear in the diagnostics (priced over w−w₀).
+    model = ParametricCostModel()
+    w0 = {s: 0.25 for s in SYMS}
+    res = MeanVarianceOptimizer(max_weight=0.5, max_names=2).optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        current_weights=w0,
+        cost_model=model,
+        cost_inputs=_inputs(0.001),
+        holding_period_years=H,
+    )
+    assert len(res.weights) <= 2
+    c_lin, _ = MeanVarianceOptimizer._cost_coefficients(model, _inputs(0.001), None, H, SYMS)
+    w = _vec(res)
+    w0v = np.array([w0[s] for s in SYMS])
+    assert res.diagnostics["turnover"] == pytest.approx(float(np.sum(np.abs(w - w0v))))
+    assert res.diagnostics["linear_cost"] == pytest.approx(float(np.sum(c_lin * np.abs(w - w0v))))
+    assert res.diagnostics["linear_cost"] > 0  # the two liquidations are charged
+
+
+def test_dust_floor_liquidation_is_priced_with_cost():
+    model = ParametricCostModel()
+    res = MeanVarianceOptimizer(max_weight=0.5, min_weight=0.1).optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=_inputs(0.001),
+        holding_period_years=H,
+    )
+    assert all(v >= 0.1 - 1e-9 for v in res.weights.values())  # no dust survives
+    assert abs(sum(res.weights.values()) - 1.0) < 1e-6
+
+
+# --- missing ADV / zero capital / linear-impact through the solve ------------
+def test_missing_adv_name_gets_linear_only_others_get_impact():
+    model = ParametricCostModel()
+    # Only A lacks ADV; the rest are illiquid enough to accrue impact.
+    ci = CostInputs(
+        spread={s: 0.0005 for s in SYMS},
+        adv_dollar={"B": 5e7, "C": 5e7, "D": 5e7},  # A omitted → kA = 0
+        daily_vol={s: 0.03 for s in SYMS},
+    )
+    c_lin, k_imp = MeanVarianceOptimizer._cost_coefficients(model, ci, 5e7, H, SYMS)
+    assert k_imp[0] == 0.0 and np.all(k_imp[1:] > 0)  # A linear-only, others conic
+    res = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=5e7,
+        holding_period_years=H,
+    )
+    assert res.feasible and abs(sum(res.weights.values()) - 1.0) < 1e-6
+
+
+def test_zero_capital_equals_linear_only_solve():
+    model = ParametricCostModel()
+    ci = _inputs(0.0005, adv_dollar=1e8)
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    zero_cap = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=0.0,
+        holding_period_years=H,
+    )
+    no_cap = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=None,
+        holding_period_years=H,
+    )
+    assert zero_cap.diagnostics["impact_cost"] == 0.0
+    assert np.allclose(_vec(zero_cap), _vec(no_cap))
+
+
+def test_linear_impact_mode_disables_the_conic_term_in_the_solve():
+    linear_model = ParametricCostModel(linear_impact=True)
+    ci = _inputs(0.0005, adv_dollar=1e7)  # illiquid → would accrue √-impact if enabled
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    lin = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=linear_model,
+        cost_inputs=ci,
+        capital=5e7,
+        holding_period_years=H,
+    )
+    only_linear = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=linear_model,
+        cost_inputs=ci,
+        capital=None,
+        holding_period_years=H,
+    )
+    assert lin.diagnostics["impact_cost"] == 0.0  # conic term not fed to the optimiser
+    assert np.allclose(_vec(lin), _vec(only_linear))
+
+
+# --- robustness: a bad cost input must not poison the solve ------------------
+def test_nan_spread_does_not_poison_the_solve():
+    model = ParametricCostModel()
+    ci = CostInputs(spread={"A": float("nan"), "B": 0.0005, "C": 0.0005, "D": 0.0005})
+    res = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
+    assert res.feasible
+    assert res.weights  # not an empty book
+    assert abs(sum(res.weights.values()) - 1.0) < 1e-6
+    assert np.isfinite(res.diagnostics["linear_cost"])

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from src.marketdata.client import MarketDataClient
 from src.risk import LedoitWolfCovariance, RiskMatrix, SampleCovariance, build_risk_matrix
@@ -158,3 +159,50 @@ def test_compute_risk_factor_model_reports_split():
     assert "factor_risk_share" in r
     assert abs(r["factor_risk_share"] + r["specific_risk_share"] - 1.0) < 1e-9
     assert set(r["factor_names"]) == {"market", "momentum", "volatility", "size"}
+
+
+def test_factor_exposures_subset_relaxes_history_requirement():
+    """A subset without momentum keeps names the full four-factor build must drop."""
+    from src.risk.exposures import build_factor_exposures
+
+    # ~90 bars: enough for volatility/size (60-bar windows), far short of 12-1 momentum.
+    bars = {s: make_ohlcv(n=90, seed=i, freq="1D") for i, s in enumerate(["AAA", "BBB", "CCC"])}
+    bench = make_ohlcv(n=90, seed=9, freq="1D")
+
+    full = build_factor_exposures(bars, bench)
+    subset = build_factor_exposures(bars, bench, factors=["market", "volatility", "size"])
+    assert full.empty
+    assert list(subset.index) == ["AAA", "BBB", "CCC"]
+    assert list(subset.columns) == ["market", "volatility", "size"]
+    # Cross-sectionally standardized: mean 0, unit dispersion per factor.
+    assert np.allclose(subset.mean().values, 0.0, atol=1e-12)
+    assert np.allclose(subset.std(ddof=0).values, 1.0, atol=1e-12)
+
+
+def test_factor_exposures_unknown_factor_raises():
+    from src.risk.exposures import build_factor_exposures
+
+    bars = {"AAA": make_ohlcv(n=200, seed=0, freq="1D")}
+    with pytest.raises(ValueError, match="value"):
+        build_factor_exposures(bars, None, factors=["market", "value"])
+
+
+def test_factor_exposures_empty_factor_list_returns_empty():
+    from src.risk.exposures import build_factor_exposures
+
+    bars = {s: make_ohlcv(n=200, seed=i, freq="1D") for i, s in enumerate(["AAA", "BBB"])}
+    assert build_factor_exposures(bars, None, factors=[]).empty
+
+
+def test_factor_exposures_reuse_precomputed_betas():
+    """A supplied beta Series is used verbatim for the market column (no re-regression)."""
+    from src.risk.exposures import build_factor_exposures
+
+    symbols = ["AAA", "BBB", "CCC"]
+    bars = {s: make_ohlcv(n=90, seed=i, freq="1D") for i, s in enumerate(symbols)}
+    bench = make_ohlcv(n=90, seed=9, freq="1D")
+    betas = pd.Series({"AAA": 0.5, "BBB": 1.0, "CCC": 1.5})
+    frame = build_factor_exposures(bars, bench, factors=["market"], betas=betas)
+    # Standardized column must be the z-score of the supplied betas exactly.
+    expected = (betas - betas.mean()) / betas.std(ddof=0)
+    assert np.allclose(frame["market"].reindex(symbols).values, expected.values)

--- a/tests/test_risk_streaming.py
+++ b/tests/test_risk_streaming.py
@@ -1,0 +1,215 @@
+"""Tests for the out-of-core streaming sample covariance (spec 015 follow-on).
+
+Proves the streaming estimator reproduces the eager ``build_risk_matrix`` oracle
+(to machine epsilon) and that it runs in memory bounded by chunk size, not history.
+Skipped unless the ``store`` extra (pyarrow + polars) is installed.
+"""
+
+import numpy as np
+import pytest
+
+pytest.importorskip("pyarrow")
+pytest.importorskip("polars")
+
+import pandas as pd  # noqa: E402
+
+from src.data import ParquetBarStore  # noqa: E402
+from src.risk import (  # noqa: E402
+    build_factor_exposures,
+    build_factor_risk_matrix,
+    build_risk_matrix,
+    streaming_factor_risk_matrix,
+    streaming_sample_covariance,
+)
+from src.risk.sample import SampleCovariance  # noqa: E402
+from tests.fakes import make_ohlcv  # noqa: E402
+
+SYMBOLS = ["AAA", "BBB", "CCC", "DDD", "EEE"]
+PPY = 252.0
+
+
+def _store(tmp_path, n=300):
+    bars = {s: make_ohlcv(n=n, seed=i, freq="1D") for i, s in enumerate(SYMBOLS)}
+    store = ParquetBarStore(tmp_path)
+    store.write(bars, timeframe="1Day")
+    as_of = max(b.index[-1] for b in bars.values()).to_pydatetime()
+    return store, bars, as_of
+
+
+def _aligned(eager, streamed):
+    """Reindex the eager Σ to the streamed symbol order for an apples-to-apples compare."""
+    idx = [eager.symbols.index(s) for s in streamed.symbols]
+    return eager.sigma[np.ix_(idx, idx)]
+
+
+def test_matches_eager_build_risk_matrix(tmp_path):
+    store, bars, as_of = _store(tmp_path)
+    eager = build_risk_matrix(SampleCovariance(), bars, PPY, min_obs=60)
+    streamed = streaming_sample_covariance(
+        store, SYMBOLS, "1Day", as_of, lookback_days=10_000, periods_per_year=PPY, min_obs=60
+    )
+    assert set(streamed.symbols) == set(eager.symbols)
+    np.testing.assert_allclose(streamed.sigma, _aligned(eager, streamed), atol=1e-12)
+    assert streamed.shrinkage is None
+
+
+def test_chunk_size_does_not_change_result(tmp_path):
+    store, _, as_of = _store(tmp_path)
+    ref = streaming_sample_covariance(
+        store, SYMBOLS, "1Day", as_of, lookback_days=10_000, periods_per_year=PPY, chunk_obs=10_000
+    )
+    for chunk in (16, 37, 128):
+        got = streaming_sample_covariance(
+            store, SYMBOLS, "1Day", as_of, lookback_days=10_000, periods_per_year=PPY, chunk_obs=chunk
+        )
+        np.testing.assert_allclose(got.sigma, ref.sigma, atol=1e-12)
+
+
+def test_is_positive_definite_and_annualised(tmp_path):
+    store, _, as_of = _store(tmp_path)
+    streamed = streaming_sample_covariance(store, SYMBOLS, "1Day", as_of, lookback_days=10_000)
+    # Variances are annualised (×252) and the matrix is usable by the optimiser.
+    assert streamed.is_positive_definite()
+    daily = streaming_sample_covariance(
+        store, SYMBOLS, "1Day", as_of, lookback_days=10_000, periods_per_year=1.0
+    )
+    np.testing.assert_allclose(streamed.sigma, daily.sigma * 252.0, atol=1e-12)
+
+
+def test_under_sampled_names_dropped_like_oracle(tmp_path):
+    # A name with < min_obs returns is excluded from the streamed kept-set, matching
+    # build_return_panel's `kept` selection.
+    bars = {s: make_ohlcv(n=300, seed=i, freq="1D") for i, s in enumerate(["AAA", "BBB"])}
+    bars["SHORT"] = make_ohlcv(n=20, seed=99, freq="1D")  # only 19 returns < min_obs=60
+    store = ParquetBarStore(tmp_path)
+    store.write(bars, timeframe="1Day")
+    as_of = max(b.index[-1] for b in bars.values()).to_pydatetime()
+    streamed = streaming_sample_covariance(
+        store, ["AAA", "BBB", "SHORT"], "1Day", as_of, lookback_days=10_000, min_obs=60
+    )
+    assert set(streamed.symbols) == {"AAA", "BBB"}
+
+
+def test_kept_order_follows_universe(tmp_path):
+    store, _, as_of = _store(tmp_path)
+    universe = ["CCC", "AAA", "EEE", "BBB", "DDD"]
+    streamed = streaming_sample_covariance(store, universe, "1Day", as_of, lookback_days=10_000)
+    assert streamed.symbols == universe  # all well-sampled → preserved in universe order
+
+
+def test_too_few_observations_returns_none(tmp_path):
+    bars = {"AAA": make_ohlcv(n=20, seed=0, freq="1D")}  # < min_obs
+    store = ParquetBarStore(tmp_path)
+    store.write(bars, timeframe="1Day")
+    as_of = bars["AAA"].index[-1].to_pydatetime()
+    assert streaming_sample_covariance(store, ["AAA"], "1Day", as_of, min_obs=60) is None
+
+
+def test_matches_oracle_across_year_boundary(tmp_path):
+    # Multi-year history: the streamed estimate (which chunks across year partitions)
+    # still matches the eager oracle exactly.
+    idx = pd.date_range("2019-01-01", periods=365 * 4, freq="1D", tz="UTC")
+    bars = {}
+    for i, s in enumerate(["AAA", "BBB", "CCC"]):
+        rng = np.random.default_rng(i)
+        close = 100.0 * np.exp(np.cumsum(rng.normal(0, 0.01, len(idx))))
+        bars[s] = pd.DataFrame(
+            {"open": close, "high": close, "low": close, "close": close, "volume": 1.0}, index=idx
+        )
+    store = ParquetBarStore(tmp_path)
+    store.write(bars, timeframe="1Day")
+    as_of = idx[-1].to_pydatetime()
+    eager = build_risk_matrix(SampleCovariance(), bars, PPY, min_obs=60)
+    streamed = streaming_sample_covariance(
+        store, ["AAA", "BBB", "CCC"], "1Day", as_of, lookback_days=10_000, chunk_obs=200
+    )
+    np.testing.assert_allclose(streamed.sigma, _aligned(eager, streamed), atol=1e-12)
+
+
+def test_streaming_peak_below_eager_on_long_history(tmp_path):
+    # The point of the migration: on a long, wide history the streaming path peaks well
+    # below the eager build_risk_matrix, which materialises the full T×N return panel.
+    import tracemalloc
+
+    wide = [f"S{i}" for i in range(20)]
+
+    def build(n, tag):
+        bars = {s: make_ohlcv(n=n, seed=i, freq="1D") for i, s in enumerate(wide)}
+        store = ParquetBarStore(tmp_path / tag)
+        store.write(bars, timeframe="1Day")
+        as_of = max(b.index[-1] for b in bars.values()).to_pydatetime()
+        return bars, store, as_of
+
+    # Warm up Polars' one-time fixed allocations OUTSIDE the measured window.
+    _, warm_store, warm_as_of = build(60, "warm")
+    streaming_sample_covariance(warm_store, wide, "1Day", warm_as_of, lookback_days=10_000, chunk_obs=64)
+
+    bars, store, as_of = build(4000, "big")
+    tracemalloc.start()
+    streaming_sample_covariance(store, wide, "1Day", as_of, lookback_days=10_000, chunk_obs=64)
+    streaming_peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+
+    tracemalloc.start()
+    build_risk_matrix(SampleCovariance(), bars, PPY, min_obs=60)
+    eager_peak = tracemalloc.get_traced_memory()[1]
+    tracemalloc.stop()
+
+    assert streaming_peak < eager_peak  # never holds the T×N panel
+
+
+# --------------------------------------------------------------------------- #
+# Streaming factor risk model (Σ = X F Xᵀ + Δ) vs the eager estimate_factor_model
+# --------------------------------------------------------------------------- #
+def _factor_setup(tmp_path, n=300, syms=("AAA", "BBB", "CCC", "DDD", "EEE", "FFF")):
+    bars = {s: make_ohlcv(n=n, seed=i, freq="1D") for i, s in enumerate(syms)}
+    benchmark = make_ohlcv(n=n, seed=99, freq="1D")
+    store = ParquetBarStore(tmp_path)
+    store.write(bars, timeframe="1Day")
+    as_of = max(b.index[-1] for b in bars.values()).to_pydatetime()
+    return store, bars, benchmark, list(syms), as_of
+
+
+def test_factor_matches_eager_estimate(tmp_path):
+    store, bars, benchmark, syms, as_of = _factor_setup(tmp_path)
+    eager = build_factor_risk_matrix(bars, benchmark, PPY, min_obs=60)
+    exposures = build_factor_exposures(bars, benchmark)
+    streamed = streaming_factor_risk_matrix(
+        store, syms, "1Day", as_of, exposures, lookback_days=10_000, periods_per_year=PPY, min_obs=60
+    )
+    assert streamed.symbols == eager.symbols
+    np.testing.assert_allclose(streamed.sigma, eager.sigma, atol=1e-12)
+    np.testing.assert_allclose(streamed.factor_cov, eager.factor_cov, atol=1e-12)
+    np.testing.assert_allclose(streamed.specific_var, eager.specific_var, atol=1e-12)
+    assert streamed.factor_names == eager.factor_names
+
+
+def test_factor_chunk_invariant(tmp_path):
+    store, bars, benchmark, syms, as_of = _factor_setup(tmp_path)
+    exposures = build_factor_exposures(bars, benchmark)
+    ref = streaming_factor_risk_matrix(
+        store, syms, "1Day", as_of, exposures, lookback_days=10_000, chunk_obs=10_000
+    )
+    for chunk in (16, 50, 128):
+        got = streaming_factor_risk_matrix(
+            store, syms, "1Day", as_of, exposures, lookback_days=10_000, chunk_obs=chunk
+        )
+        np.testing.assert_allclose(got.sigma, ref.sigma, atol=1e-12)
+        np.testing.assert_allclose(got.factor_cov, ref.factor_cov, atol=1e-12)
+
+
+def test_factor_attribution_quantities_usable(tmp_path):
+    store, bars, benchmark, syms, as_of = _factor_setup(tmp_path)
+    exposures = build_factor_exposures(bars, benchmark)
+    streamed = streaming_factor_risk_matrix(store, syms, "1Day", as_of, exposures, lookback_days=10_000)
+    w = {s: 1.0 / len(streamed.symbols) for s in streamed.symbols}
+    # The factor/specific split is consistent and the streamed Σ is positive-definite.
+    assert streamed.factor_variance(w) >= 0 and streamed.specific_variance(w) >= 0
+    assert streamed.is_positive_definite()
+
+
+def test_factor_drops_names_without_exposure(tmp_path):
+    store, bars, benchmark, syms, as_of = _factor_setup(tmp_path)
+    exposures = build_factor_exposures(bars, benchmark).drop(index="CCC")  # no exposure for CCC
+    streamed = streaming_factor_risk_matrix(store, syms, "1Day", as_of, exposures, lookback_days=10_000)
+    assert "CCC" not in streamed.symbols and set(streamed.symbols) <= set(syms)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -7,7 +7,9 @@ import pytest
 
 pytest.importorskip("pyarrow")
 
-from datetime import datetime  # noqa: E402
+from datetime import datetime, timezone  # noqa: E402
+
+import pandas as pd  # noqa: E402
 
 from src.data import BarSource, ClientBarSource, ParquetBarStore  # noqa: E402
 from src.marketdata.client import MarketDataClient  # noqa: E402
@@ -18,6 +20,14 @@ SYMBOLS = ["AAA", "BBB", "CCC"]
 
 def _bars():
     return {s: make_ohlcv(n=300, seed=i, freq="1D") for i, s in enumerate(SYMBOLS)}
+
+
+def _multiyear_bars(start="2018-01-01", years=6):
+    # Daily bars spanning several calendar years, so the year= partitions are exercised.
+    idx = pd.date_range(start, periods=365 * years, freq="1D", tz="UTC")
+    close = pd.Series(range(len(idx)), index=idx, dtype=float) + 100.0
+    frame = pd.DataFrame({c: close for c in ("open", "high", "low", "close", "volume")}, index=idx)
+    return {"AAA": frame}
 
 
 def test_is_a_bar_source(tmp_path):
@@ -111,3 +121,53 @@ def test_streaming_backtest_matches_batch(tmp_path):
     )
     assert streamed.final_capital == pytest.approx(batch.final_capital)
     assert len(streamed.trades) == len(batch.trades)
+
+
+# --------------------------------------------------------------------------- #
+# Date-partitioned layout (symbol=…/year=…) and file-level date pruning (spec 015)
+# --------------------------------------------------------------------------- #
+def test_write_creates_year_partitions(tmp_path):
+    store = ParquetBarStore(tmp_path)
+    store.write(_multiyear_bars(start="2018-01-01", years=6), timeframe="1Day")
+    years = sorted(p.name for p in (tmp_path / "1Day" / "symbol=AAA").glob("year=*"))
+    assert years == [f"year={y}" for y in range(2018, 2024)]  # one partition per calendar year
+
+
+def test_windowed_scan_prunes_partition_files(tmp_path):
+    store = ParquetBarStore(tmp_path)
+    store.write(_multiyear_bars(start="2018-01-01", years=6), timeframe="1Day")
+    as_of = datetime(2021, 6, 1, tzinfo=timezone.utc)
+
+    all_files = store.partition_paths(["AAA"], "1Day")  # every year
+    pruned = store.partition_paths(["AAA"], "1Day", as_of=as_of, lookback_days=200)
+    assert len(all_files) == 6
+    # A ~200-day window ending mid-2021 spans only 2020–2021 → 2 partition files read.
+    assert len(pruned) < len(all_files)
+    assert all(("year=2020" in p or "year=2021" in p) for p in pruned)
+
+
+def test_windowed_scan_data_correct_across_years(tmp_path):
+    # File-level pruning must not drop in-window rows: the scan still returns exactly
+    # the bars in (as_of - lookback, as_of], spanning the year boundary.
+    store = ParquetBarStore(tmp_path)
+    bars = _multiyear_bars(start="2018-01-01", years=6)
+    store.write(bars, timeframe="1Day")
+    as_of = datetime(2021, 3, 1, tzinfo=timezone.utc)
+    scanned = store.scan(["AAA"], "1Day", as_of, lookback_days=120)["AAA"]
+    original = bars["AAA"]
+    expected = original[
+        (original.index > (pd.Timestamp(as_of) - pd.Timedelta(days=120)))
+        & (original.index <= pd.Timestamp(as_of))
+    ]
+    assert len(scanned) == len(expected)
+    assert scanned.index.min().year == 2020 and scanned.index.max().year == 2021  # crosses the boundary
+    assert scanned["close"].to_numpy() == pytest.approx(expected["close"].to_numpy())
+
+
+def test_rewrite_replaces_stale_year_partitions(tmp_path):
+    # Re-writing a symbol with a shorter history must not leave stale year partitions.
+    store = ParquetBarStore(tmp_path)
+    store.write(_multiyear_bars(start="2018-01-01", years=6), timeframe="1Day")
+    store.write(_multiyear_bars(start="2022-01-01", years=1), timeframe="1Day")  # only 2022
+    years = sorted(p.name for p in (tmp_path / "1Day" / "symbol=AAA").glob("year=*"))
+    assert years == ["year=2022"]

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -13,9 +13,16 @@ import pandas as pd  # noqa: E402
 
 from src.data import BarSource, ClientBarSource, ParquetBarStore  # noqa: E402
 from src.marketdata.client import MarketDataClient  # noqa: E402
+from src.marketdata.timeframe import Timeframe  # noqa: E402
 from tests.fakes import DictMarketData, make_ohlcv  # noqa: E402
 
 SYMBOLS = ["AAA", "BBB", "CCC"]
+
+#: The store normalises the timeframe to its canonical directory name (e.g. "1day"),
+#: which differs in case from the "1Day" people type. Derive it rather than hardcode
+#: the string so raw-path assertions match the on-disk layout on case-sensitive
+#: filesystems (Linux CI), not just case-insensitive ones (default macOS).
+TF_DIR = str(Timeframe.parse("1Day"))
 
 
 def _bars():
@@ -129,7 +136,7 @@ def test_streaming_backtest_matches_batch(tmp_path):
 def test_write_creates_year_partitions(tmp_path):
     store = ParquetBarStore(tmp_path)
     store.write(_multiyear_bars(start="2018-01-01", years=6), timeframe="1Day")
-    years = sorted(p.name for p in (tmp_path / "1Day" / "symbol=AAA").glob("year=*"))
+    years = sorted(p.name for p in (tmp_path / TF_DIR / "symbol=AAA").glob("year=*"))
     assert years == [f"year={y}" for y in range(2018, 2024)]  # one partition per calendar year
 
 
@@ -169,5 +176,5 @@ def test_rewrite_replaces_stale_year_partitions(tmp_path):
     store = ParquetBarStore(tmp_path)
     store.write(_multiyear_bars(start="2018-01-01", years=6), timeframe="1Day")
     store.write(_multiyear_bars(start="2022-01-01", years=1), timeframe="1Day")  # only 2022
-    years = sorted(p.name for p in (tmp_path / "1Day" / "symbol=AAA").glob("year=*"))
+    years = sorted(p.name for p in (tmp_path / TF_DIR / "symbol=AAA").glob("year=*"))
     assert years == ["year=2022"]

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,48 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/29/9bad86ed7aa812d8c822a27c15c355b6d5423b991feeec86ed18027b6daa/duckdb-1.5.4.tar.gz", hash = "sha256:f9e32f1cdd106793d79d190186bed9e75289d51e68bd9174e47c04bffedeab6f", size = 18046634, upload-time = "2026-06-17T10:48:52.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/ee/69340af74a3aa21838f14c16a0dd3e58461896ccba41f6bc7f0a01536e23/duckdb-1.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3ddd9533ce80f9b851bdd6276960a9286166514a9ceca43d5bc2f0d5842c490d", size = 32656177, upload-time = "2026-06-17T10:47:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/9da267ade389d4e7e533ac0c77b3a7041513a66efab93beb84f27627b0b8/duckdb-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360f2542d09759c3739400f8b787e29b43ba0da665c21756216291458bf6fc59", size = 17318966, upload-time = "2026-06-17T10:47:33.688Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/ad73c1a396288e443b18af50819448060b318c1e933305167c1d7f98a507/duckdb-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0cf932055061e544d3fa27cc6c147da25f3f681ee5980157fb55e77d6c2d9c63", size = 15467572, upload-time = "2026-06-17T10:47:36.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/06/2c52ce3b97c3f21111f3c98a2121ed002e33f86488f55098a37825af6d4a/duckdb-1.5.4-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2d58d39f5e65419cdc27e3875cba4a729a3bbf6bf4016aefb4a2a65335a1d42", size = 19344044, upload-time = "2026-06-17T10:47:38.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/7d/5c0cc66fb90a1b14474eebb5ab535eacc51cb20b0e45358348b51c07abc9/duckdb-1.5.4-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9a10dc40469b9c0e458625d2a8359461a982c6151bb53ff259fea00c4695ad4", size = 21448215, upload-time = "2026-06-17T10:47:40.617Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/16c3ea201855cdfb7dde52ea3678d0536861cb485ffad46cf345436d658d/duckdb-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:3565550adbf160ef7a2ee3395470570182f11233983ad818bd7d5f9e349f92b2", size = 13132138, upload-time = "2026-06-17T10:47:43.085Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bb/7921dabd50daef3969f14cd8a5a14c24eee337db7914a462f2defa8add92/duckdb-1.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3fb41d9cfccb7e44511eeeed263ae98143ca63bdb1ef84631ba637c314efa1b5", size = 32663142, upload-time = "2026-06-17T10:47:45.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/83/2137765eaba6a9aefe3bb9848ddaac7407fe3ba19b292f98b31f3b7ab27f/duckdb-1.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ba7b666bc9c78d6a930ee9f469024149f0c6a23fb7d2c3418aad6774339bec0", size = 17321485, upload-time = "2026-06-17T10:47:47.778Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b2/a02c1ee43fd7e8cf1fc2e3d377f3dcf9d4a3e58a4549557516e1866ff0da/duckdb-1.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9d9e6817fcbc09d2605a2c8c041ac7824d738d917c35a4d427e977647e1d7944", size = 15470820, upload-time = "2026-06-17T10:47:49.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/48/a243d30223b024bc6057abe472b002cff01e97efefb4d2f0b0dcc5aece0b/duckdb-1.5.4-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02dd9f9a6124069213f13e3a474c208028c472fe1acdae12b38761f954fe4fc6", size = 19341849, upload-time = "2026-06-17T10:47:52.205Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/a5d48de4771e2403a8ef26a20dc7457b1c8f7e398ff0caf9c0cad8805f89/duckdb-1.5.4-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccc7f2694d02b4763fee61021d45e12f7bc5743993686563957df0cef799fbae", size = 21451698, upload-time = "2026-06-17T10:47:54.653Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/8244d7741b4afae67775cf0cb0d4eb9e923a83110907e4801e17fa078480/duckdb-1.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:4c430e788d99b50854209bf2833ba36a45df75e57f86efb477046cd408bbd077", size = 13132643, upload-time = "2026-06-17T10:47:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/57/8169822a37f6dd7d561c567f9007e3cf04bf97bccb619afe90db849c0962/duckdb-1.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:e2dc8340cfb6006025a798c50f40126d6e945a1d2487be94667bb4166556ce7b", size = 13986386, upload-time = "2026-06-17T10:47:59.345Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f2/e2f4b477ae3a3b40e8b5f429832e48edb62ed9da99807cc4902e157e5646/duckdb-1.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:291a9e7502551170af989ff63139a7a49e99d68edbc5ef5017ac27541fe54c65", size = 32708876, upload-time = "2026-06-17T10:48:01.527Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2b/b698d82a5e1e30b6a05748d72045f672994c6b22f4f0f8423523608b991f/duckdb-1.5.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:83e8c089bbb756ca4471d8b05943b80a106058697cf00615e70423106bb783bc", size = 17346125, upload-time = "2026-06-17T10:48:04.035Z" },
+    { url = "https://files.pythonhosted.org/packages/71/75/37e13f39268eaf34864453b3a039c4a1ff0b088d3eae45a4289b41c98c1b/duckdb-1.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff96d2a342b200e1ec6f1f19986c77f4ac16a49b6112f71c5b763989203a9d60", size = 15488133, upload-time = "2026-06-17T10:48:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/59/2d082af578f689231798245b54562c61416e49049b0bda81a06c56a4b53e/duckdb-1.5.4-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f935ef210ab00bc94bb1e3052697adaa36bb0ce7bdfeda8b0f34e2ff1643870", size = 19367895, upload-time = "2026-06-17T10:48:08.59Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/55c34d2863a76ca824ef8274691e84240b4ff1acde3d231709e82557c240/duckdb-1.5.4-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cda263d8c20addb8d4f95464787cbe0af1144f7ab7e21db3709fb826ee01725", size = 21486499, upload-time = "2026-06-17T10:48:10.963Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/30/ade5952b8182fac86fab43b95ebe3836e66381d0ad64eb1e54bd8207c988/duckdb-1.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:266c7c909558ce7377f57d082cee408aadebdd9111be017558ca54e44a031037", size = 13147934, upload-time = "2026-06-17T10:48:13.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/278f0f70e25b9911afe2fd227b9460f2e6d76177f0dcc03f7f1454afefa5/duckdb-1.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:f14e79a006341f29ee5a2692a24dac5114e77533d579c57ec39124adf0135033", size = 13965235, upload-time = "2026-06-17T10:48:15.782Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/3fcb34e523a9bad1f0557a6c7691a71ba66c43a05e5be9ee96a9a841ed65/duckdb-1.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:42a612e67d64450b446eb69695290d460713eef46e0f64467ab9dfe96264ee05", size = 32708366, upload-time = "2026-06-17T10:48:18.084Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/bff5054c2c1d65decab36aa6296621e51a2a575a9f250db7ab9b83a325d6/duckdb-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fb6f07d54ecf4d0d3c5179a2361fdddfafa14de4fc42696de4632479b703421", size = 17345735, upload-time = "2026-06-17T10:48:20.67Z" },
+    { url = "https://files.pythonhosted.org/packages/93/12/d1b2b344e9699246aada6f9de5156e708fb476e2780e5bff9b5d95fe11d9/duckdb-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f32ad7e0286c1c29ab6c73b29118c86101f8eee46aae54f54d0b50916f542f6", size = 15488568, upload-time = "2026-06-17T10:48:23.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/ac56c6096e3e95da60b2c5dd5a0f0eb5540a80622e2e4f8faab893ec4e96/duckdb-1.5.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:698ec90bd5d5538bd5f6d212a4b61af443d240703cf45f134738535026556ea5", size = 19368184, upload-time = "2026-06-17T10:48:25.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/2ae4c3e157a19d9b4ac1f09a5dea6f93012334cc2db09f1e0c71eb99693d/duckdb-1.5.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136cea7f886b78caf4035485b4b1e766e8b309e999f9e83a966f81ebb8122844", size = 21486523, upload-time = "2026-06-17T10:48:27.817Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/c3d8d21e0d0db8faa81eeeb3a55b9932f5a0a16466cb968dc713a653d701/duckdb-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:bd6777e8ddd74fb603a6d09766bfcff28638189f8aaa61fc0dffd9e9a4baa8e5", size = 13147807, upload-time = "2026-06-17T10:48:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/ddf8d3740e3d28582944f70d84e720b5dc28c10ec22b668a0e0bd965f2f2/duckdb-1.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:73f4878a3012283024a64a1909e440aac12091ef336f671fc142f7e87449ce0c", size = 13965189, upload-time = "2026-06-17T10:48:32.251Z" },
+    { url = "https://files.pythonhosted.org/packages/62/01/67ac4cbc8e552a1e14c029b5c443d828e68f94d5d913c574f577e1db277e/duckdb-1.5.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4647968629d0677bbcc2416c7aeda8685eb84e4ca15a6dbd4f82a66cfc91a532", size = 32714364, upload-time = "2026-06-17T10:48:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/eb44d983fa56b175f971eea251bde284a36d26cbb93fcb68035061f54078/duckdb-1.5.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e8fcef301cf68d3951ea1eb8ac4d76cea0a6f6a08f4c78fe4026fc96d217bebc", size = 17349820, upload-time = "2026-06-17T10:48:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b2/b9dc7624b105d414585b8530451c1162c0b4750c0be9be2e497bb47a8a9b/duckdb-1.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f6f39cd0dc6948dee17fd130aec55114f97a8ef6e1db519b9774087962bc5c8c", size = 15498160, upload-time = "2026-06-17T10:48:40.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/61356444f6a8c62dec3c3d129abfc53f428de1d484093d1bb381db441231/duckdb-1.5.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:262f068158beb5943f2c618f4e54b46db8306b959f90dce956f90a89f613673d", size = 19374183, upload-time = "2026-06-17T10:48:42.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f4/d5d633dd7c5138d8f7c434e6ac2553c831b7fb658494efa8d0bc73df8623/duckdb-1.5.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d2307a76d199077b0055b354e90e857479461a0d875437535dd4833172c8b6d", size = 21487202, upload-time = "2026-06-17T10:48:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/26/5be13bbd5c3421dccfc1ad4ca9da4b97c5a3ddd73f66542092f3167ec52c/duckdb-1.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:6dcbb81a1276bc48deb4d562bce4f8895e4fc6348750a096e30052345c6d6552", size = 13666989, upload-time = "2026-06-17T10:48:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/4d52f3f9f9703a226b26b80bdae3f6905aeefe5221bf1815fc93ff02ca25/duckdb-1.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:0f8722346024e5d9f02b58bf7b0491a629f97fdc8a04a10e432940f471ee387a", size = 14449863, upload-time = "2026-06-17T10:48:50.18Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1678,6 +1720,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/99/fe77f10a13a778705ef05b499fc708c9a0b0a3680d9eb6bc6e1b6a6b9914/polars-1.42.1.tar.gz", hash = "sha256:2fe94f3059334650bd850ae19a9c165dcd5d9cb12cd95ea04de2201662e70e8a", size = 741532, upload-time = "2026-06-30T04:57:51.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/6a/edd939cc6fa04b6415aaa9bf19720fc74ead81234b3d38542e0005816d4d/polars-1.42.1-py3-none-any.whl", hash = "sha256:3c0c65cdfa21a621650c4bdcbbccf93964d052fd766c3e70e84a55d961c259fd", size = 837622, upload-time = "2026-06-30T04:56:34.686Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/59/15bcc4dac380c6d63efa5446d8317f22671cbd6c9dadd576bd17a334c45a/polars_runtime_32-1.42.1.tar.gz", hash = "sha256:4d4809e1c1b9a6611f6944f27b24abea902b5159e6b6fa262fd716e947af5afd", size = 3045460, upload-time = "2026-06-30T04:57:52.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/29/16ff6e4e91d71e530d3581f45e342a9cc35072ac6b31dcbc2fa33de2569e/polars_runtime_32-1.42.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bbdc26d68ee5b23b0ce227fa0599220aa35b77c826b6b0a6b2d8e7f6c1c36974", size = 53117325, upload-time = "2026-06-30T04:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8e/4f8296fcfd1347f1351342fecf13bf2430d7efbae2f1f45964ec7930a99e/polars_runtime_32-1.42.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f6c0288be940b607dc4a7476c01e67fb6bbee93f5f1dd42c64970274c71008ba", size = 47446251, upload-time = "2026-06-30T04:56:41.459Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2e/0d66a7deadc453b890c3391034ca8ab4b05d0beaebbb92a7d65199fba61b/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635d9dbcae2302ae223afb395d5cd220bffa61a53d0ab6871d17c8bc830101cf", size = 51359402, upload-time = "2026-06-30T04:56:44.595Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/10/ffb85fa380bc9c9000dc35f40f44954dde49023018501c54faab94b3a39e/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d059e8e53cc114ff82f9bd791fd341dc53534a2c745e6f6aa37594c3a93f01fe", size = 57302723, upload-time = "2026-06-30T04:56:47.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/63/ca50adc62e44224ca5c622a842ba6f35ee87d1d40ef0df7ea2ed6c6edb08/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f91f0b13588324905682809d270e1de5f1990c908721c8527657d77a044c9919", size = 51515673, upload-time = "2026-06-30T04:56:50.88Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c3/08fbbf38deaa17bf34a601d327cb7451074098673c78b7c1a8538dde9794/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b8bf972d99d48aaaa2582e2bce966a6f43bc815bd8725d15f5cab9e2fb15d17", size = 55217259, upload-time = "2026-06-30T04:56:53.834Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/51db89361668fe077a835fc579277f824ba526e7daf7b94d23d25439e0d0/polars_runtime_32-1.42.1-cp310-abi3-win_amd64.whl", hash = "sha256:e9364c26da389a8b7339e4d29e20a3d12af730247e6ed3b7804bddce2477f428", size = 52715432, upload-time = "2026-06-30T04:56:57.109Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/2fb8592d691bd114de25d9c84300b23541dca7060eac11d7b4bed0327786/polars_runtime_32-1.42.1-cp310-abi3-win_arm64.whl", hash = "sha256:7051226e6b42ffc395a7a9190377cd28649fbfb991b8f85c6271f4e1cfb736fb", size = 46718300, upload-time = "2026-06-30T04:56:59.855Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2712,7 +2782,7 @@ wheels = [
 
 [[package]]
 name = "tradeflow"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alpaca-py" },
@@ -2728,9 +2798,11 @@ ai = [
     { name = "anthropic" },
 ]
 dev = [
+    { name = "duckdb" },
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "ortools" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
@@ -2751,6 +2823,8 @@ portfolio = [
     { name = "ortools" },
 ]
 store = [
+    { name = "duckdb" },
+    { name = "polars" },
     { name = "pyarrow" },
 ]
 viz = [
@@ -2762,6 +2836,8 @@ viz = [
 requires-dist = [
     { name = "alpaca-py", specifier = ">=0.35" },
     { name = "anthropic", marker = "extra == 'ai'", specifier = ">=0.40" },
+    { name = "duckdb", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "duckdb", marker = "extra == 'store'", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.8" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
@@ -2770,6 +2846,8 @@ requires-dist = [
     { name = "ortools", marker = "extra == 'dev'", specifier = ">=9.8" },
     { name = "ortools", marker = "extra == 'portfolio'", specifier = ">=9.8" },
     { name = "pandas", specifier = ">=2.0" },
+    { name = "polars", marker = "extra == 'dev'", specifier = ">=1.25" },
+    { name = "polars", marker = "extra == 'store'", specifier = ">=1.25" },
     { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=14" },
     { name = "pyarrow", marker = "extra == 'store'", specifier = ">=14" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },

--- a/website/docs/engineering/alphas.md
+++ b/website/docs/engineering/alphas.md
@@ -67,16 +67,52 @@ model, so the scaling identity and the as-of discipline live in exactly one plac
 
 Alphas should be **benchmark-neutral** — the equal-weighted average alpha ≈ 0 — so
 they express only *relative* views and don't smuggle in a directional market bet.
-Two levers, both in `refine.neutralize` (an OLS residual, orthogonal to the supplied
-exposures by construction, with an intercept so the residual is mean-zero):
+Two levers, both ending in `refine.neutralize` (an OLS residual, orthogonal to the
+supplied exposures by construction, with an intercept so the residual is mean-zero):
 
-- **Benchmark-beta neutral** (always available): regress `z` on each name's beta and
-  keep the residual. Enabled by `--neutralize`.
-- **Factor neutral** (when a factor risk model exists): regress on the
-  factor-exposure matrix so the alpha is orthogonal to size/momentum/vol.
+- **Benchmark-beta neutral**: regress `z` on each name's beta and keep the residual.
+  Enabled by `--neutralize`.
+- **Factor neutral**: regress on the [risk model's](./risk-model.md) standardized
+  factor exposures (`exp_<factor>` panel columns, written by
+  `add_factor_exposure_features` from the *same* builder the factor risk model uses —
+  one definition of "factor", both places). Enabled by `--neutralize-factors`; the
+  bare flag neutralizes **market, volatility, size**. **Momentum is deliberately not
+  in the default set** — a momentum tilt is a return bet the alpha may intend;
+  regress it out explicitly (`--neutralize-factors market,volatility,size,momentum`)
+  if that's the goal.
 
 The z-score already centres the cross-section at 0, so equal-weight benchmark
 neutrality holds even before the explicit step.
+
+Both levers compose into **one regression on the union** of exposures, with three
+rules that keep degraded inputs honest rather than silently wrong:
+
+1. **Usability gating.** A factor column is used only if it exists and actually
+   varies across covered names. An absent, all-NaN, or constant column (e.g. the
+   exposure build qualified fewer than two names on a short-history universe)
+   **degrades to plain-beta neutralisation — never to no neutralisation**.
+2. **Mean-imputation for partial coverage.** A name missing one factor value gets
+   the cross-sectional mean (0 — exposures are standardized), keeping it *in* the
+   regression. Without this, the union's row-wise NaN-drop would strip that name's
+   beta neutralisation too, and the cross-section would silently mix neutralized and
+   raw scores.
+3. **Report what was applied, not what was asked.** The refinement records
+   `panel.meta["neutralized_against"]` (and an imputation count); the services echo
+   it as `neutralized_against`, and the CLI prints it — with an explicit warning when
+   a requested factor's exposures were unavailable. "Factor-neutral" is never claimed
+   for un-neutralized output.
+
+:::note Known limitations (deliberate, tracked)
+- The **MCP tools don't expose `neutralize_factors` yet** — results echo the field
+  (always `[]` via that surface); wiring the parameter through
+  [`src/mcp/server.py`](./mcp-server.md) is a small follow-up for when the agent
+  surface needs it.
+- The exposure builder's **history gate is two-way, not per-factor**: a subset with
+  momentum requires the full 12-1 window (~148 bars), any other subset requires
+  `vol_window + 1` (61) bars — even for factors (like market) that could tolerate
+  less. Names between those bounds are dropped from the exposure frame (then
+  mean-imputed per rule 2).
+:::
 
 ## The feature panel and refinement
 

--- a/website/docs/engineering/data-panel.md
+++ b/website/docs/engineering/data-panel.md
@@ -68,14 +68,16 @@ Each module is a column producer, a consumer, or both:
 | Producer | Writes |
 |----------|--------|
 | `add_risk_features` | `beta`, `residual_vol` (annualised; falls back to total vol with no benchmark) |
+| `add_factor_exposure_features` | `exp_<factor>` (the [risk model's](./risk-model) standardized exposures, for [factor-neutral alphas](./alphas#neutralization); reuses the panel's `beta`, writes nothing if `<2` names qualify) |
 | `add_score_feature` | `score` (applies any `scorer`: a strategy, a scanner, …) |
 
 | Consumer | Reads → writes |
 |----------|----------------|
-| `refine_alpha` ([alphas](./alphas)) | `score`, `residual_vol`, `beta` → `z`, `alpha` |
+| `refine_alpha` ([alphas](./alphas)) | `score`, `residual_vol`, `beta`, `exp_*` → `z`, `alpha` (+ `meta.neutralized_against`) |
 
-New producers (factor exposures, transaction-cost params, liquidity) slot in the same
-way, and consumers downstream don't change.
+New producers (transaction-cost params, liquidity) slot in the same way, and
+consumers downstream don't change — the factor-exposure producer arrived exactly
+this way.
 
 ## Why it's shaped this way
 

--- a/website/docs/engineering/mcp-server.md
+++ b/website/docs/engineering/mcp-server.md
@@ -54,8 +54,18 @@ service function, logs the call, and returns JSON. The exposed surface:
 - Discovery: `list_strategies`, `list_scanners`, `get_param_ranges`
 - Analyze: `run_scan`, `run_backtest`, `run_optimization`, `run_walk_forward`,
   `get_metrics_glossary`, `summarize_bars`
+- Research: `compute_alphas`, `combine_alphas`, `compute_risk`,
+  `construct_portfolio`, `compute_information`, `compute_horizon`
 - Propose (writes a file, never live state): `save_config`, `load_config`,
   `list_configs`
+
+:::note Known gap
+The research tools don't expose the CLI's `neutralize_factors` parameter yet
+([factor-neutral alphas](./alphas.md#neutralization)) — their results echo a
+`neutralized_against` field, but via this surface it is always empty. Wiring the
+parameter through the tool signatures is a small follow-up for when the agent
+surface needs it.
+:::
 
 ## The hard wall
 

--- a/website/docs/engineering/risk-model.md
+++ b/website/docs/engineering/risk-model.md
@@ -66,6 +66,15 @@ Two estimators behind one `RiskModel.estimate(returns)` interface:
   *factor* risk (`w_aᵀ X F Xᵀ w_a`) and *specific* risk (`w_aᵀ Δ w_a`). `risk --model
   factor` reports that split; it's what makes performance attribution possible.
 
+  The exposure builder (`build_factor_exposures`) is also the source of the
+  [alpha pipeline's](./alphas.md#neutralization) factor-neutralization columns — one
+  definition of "factor", both places. For that use it accepts a **subset**
+  (`factors=[...]`, relaxing the history requirement when momentum isn't requested)
+  and **precomputed betas** (`betas=...`, so the market column reuses the panel's
+  beta regression instead of rerunning it per name). Known limitation: the history
+  gate is two-way (momentum ⇒ ~148 bars, otherwise 61), not per-factor — a
+  market-only subset still requires 61 bars.
+
 ## Edge cases it handles
 
 - **Invertibility is the whole point.** Every estimator returns a positive-definite

--- a/website/docs/usage/alphas.md
+++ b/website/docs/usage/alphas.md
@@ -45,6 +45,7 @@ residual return for the year. The ranking is what a mean-variance
 | `--ic` | `0.03` | Assumed information coefficient (sets overall aggressiveness). |
 | `--benchmark` | `SPY` | Benchmark for beta and residual volatility. |
 | `--neutralize` | off | Make alphas beta-neutral (regress out benchmark beta). |
+| `--neutralize-factors` | off | Make alphas **factor-neutral**: regress out the risk model's exposures. Bare flag = `market,volatility,size` (momentum kept — a momentum tilt is a return bet the alpha may intend); or pass a comma-separated subset. |
 | `--lookback-days` | `180` | History fetched (≤ `as_of`) for the residual-vol estimate. |
 
 Use `--source scanner` to rank by a scanner's continuous conviction instead of the
@@ -53,6 +54,35 @@ strategy's score:
 ```bash
 python main.py alphas --source scanner --scanner volume --symbols NVDA,AAPL,META --as-of 2025-06-01
 ```
+
+## Factor-neutral alphas
+
+`--neutralize-factors` regresses the scores against the
+[risk model's](../engineering/risk-model.md) standardized factor exposures, so the
+alphas can't hide an incidental market/volatility/size tilt:
+
+```bash
+python main.py alphas --strategy volume_spike --symbols ... --neutralize-factors
+```
+
+The report states what was **actually applied** — and warns when it couldn't be:
+
+```
+Alphas from 'volume_spike' score as of 2025-06-01 (IC=0.03, benchmark=SPY)
+  neutralized against: market, volatility, size
+```
+
+```
+  neutralized against: beta
+  ! requested factor(s) NOT neutralized (exposures unavailable — insufficient history?): market, volatility, size
+```
+
+The second form appears when the universe's history is too short to build the
+exposures (momentum needs ~148 daily bars, the others 61) — the pipeline then falls
+back to plain-beta neutralisation rather than silently doing nothing. Unknown factor
+names are rejected at parse time. The same flag exists on `allocate --objective
+utility` (construct from factor-neutral alphas) and on `info`/`horizon` — **measure
+the same alpha you deploy**. Note: the MCP tools don't expose this parameter yet.
 
 ## Combining several signals
 

--- a/website/docs/usage/information.md
+++ b/website/docs/usage/information.md
@@ -46,6 +46,7 @@ how inflated a "significant" result is once you account for everything you tried
 | `--benchmark` | `SPY` | Used to strip beta (residual returns). |
 | `--horizon` | `5` | Forward-return horizon, in bars. |
 | `--n-trials` | `1` | Configs tried, for the multiple-testing inflation. |
+| `--neutralize-factors` | off | Measure the **factor-neutral** alpha (bare flag = `market,volatility,size`) — use the same setting you deploy with, so the measured IC/IR describes the forecast you actually trade. Also on `horizon`. |
 
 ## What it does (and doesn't) tell you
 

--- a/website/docs/usage/portfolio.md
+++ b/website/docs/usage/portfolio.md
@@ -77,3 +77,8 @@ this Σ; the **transfer coefficient** is how much of it survives your constraint
 (tighten `--max-names` or `--max-weight` and watch it fall); **predicted IR** ≈
 `TC · IR*`. See [Portfolio construction (engineering)](../engineering/portfolio-construction)
 for the math.
+
+`--neutralize-factors` builds the book from **factor-neutral alphas** (bare flag =
+`market,volatility,size`; momentum kept as a deliberate return tilt) — see
+[Ranking by alpha](alphas#factor-neutral-alphas) for the semantics and the
+honesty warning when exposures are unavailable.


### PR DESCRIPTION
## Summary

Spec 015 — **lazy out-of-core compute** on Polars/DuckDB: the compute half of the out-of-core substrate (011 built the storage tier; this makes the panel-wide *math* scale past RAM), plus its two large follow-ons.

### Lazy compute layer (`src/data/compute.py`, `src/data/edges.py`)

- **Per-symbol indicator windows** (rolling mean/std, EWMA) as lazy Polars expressions using `.over("symbol", order_by="ts")` — correct even when partitions arrive out of timestamp order.
- **Cross-sectional ops** (z-score, winsorize, rank) `over("ts")`, mapping non-finite values to null *before* reducing — one NaN can no longer zero out a bar's z-scores or take the top rank.
- **`streaming_covariance`**: accumulates `Σxxᵀ` sufficient statistics in one streaming pass, so memory is bounded by universe size (N×N), not history length.
- **DuckDB `sql_query`** over the same Arrow data for ad-hoc research queries.
- `edges.py` keeps pandas at the *edges only* (`to_pandas`/`from_pandas`/`collect_streaming`); an unnamed `DatetimeIndex` becomes `ts` on the way in. The legacy pandas path is retained as the **equivalence oracle** in tests.
- `ParquetBarStore.scan_lazy` with `as_of` + projection pushdown — verified in the Parquet SCAN plan, with a schema-carrying empty scan for missing symbols. `polars>=1.25` (streaming engine) + `duckdb` join the optional `store` extra; the base install gains nothing.

Hardened by a 5-lens adversarial review (default-refute verification): out-of-order-partition correctness, NaN poisoning, and honest bounded-memory docstrings — only the leaf scan and `streaming_covariance` are O(1)-in-history; `over()`/sort buffer, and the docs say so.

### Follow-ons

- **Date-partitioned Hive layout**: the store is now `symbol=<SYM>/year=<YYYY>/part.parquet`; `scan`/`scan_lazy`/`partition_paths` prune to the `year=` partitions overlapping the window (file-level date pruning) before the row-group `as_of` predicate.
- **Streaming risk estimation** (`src/risk/streaming.py`): `streaming_sample_covariance` and `streaming_factor_risk_matrix` (Σ = XFXᵀ + Δ) stream the return panel in date chunks and accumulate sufficient stats — never materializing the T×N panel (a survey confirmed the covariance return panel was the only genuine T×N materialization in the codebase). Both reproduce the eager oracle to ~5e-18 and peak well below it on long history (tracemalloc-verified). Ledoit–Wolf shrinkage stays eager (it needs higher moments) — noted, not faked.
- Track package `__init__.py` files (narrow the blanket gitignore).

### Verification

277 tests pass, including eager-vs-lazy equivalence tests against the pandas oracle and the streaming-vs-eager covariance reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)