### PR TITLE
Feat/cost aware optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ doing its job.
 | `live` | Scan → warm up indicators → stream bars → place paper/live orders |
 | `optimize` | Search strategy parameters by backtest objective (grid / random / Bayesian) |
 | `allocate` | Weight a portfolio: scalar-score sizing (OR-Tools), or `--objective utility` for mean-variance construction from alpha + Σ |
-| `alphas` | Rank a universe by continuous alpha — a comparable, annualized residual-return forecast per name; `--combine` blends several signals (read-only) |
+| `alphas` | Rank a universe by continuous alpha — a comparable, annualized residual-return forecast per name; `--combine` blends several signals, `--neutralize-factors` regresses out the risk model's factor exposures (read-only) |
 | `risk` | Estimate the universe covariance Σ (Ledoit–Wolf shrinkage) and summarize its risk structure (read-only) |
 | `info` | Information report: measure IC, breadth, and predicted-vs-realized IR — skill vs luck (read-only) |
 | `horizon` | Measure alpha decay / half-life; recommend rebalance cadence + current/lagged blend (read-only) |

--- a/main.py
+++ b/main.py
@@ -178,18 +178,30 @@ def _allocate_utility(args) -> None:
         max_names=args.max_names,
         benchmark=args.benchmark,
         capital=args.capital,
+        holding_period_years=args.holding_period,
+        cost_aware=not args.gross_objective,
     )
     if not result["feasible"]:
         print(f"Infeasible: {result.get('binding_constraint') or result.get('note')}")
         return
 
     d = result["diagnostics"]
-    print(f"\nPortfolio for '{args.strategy}' as of {args.as_of:%Y-%m-%d} (target TE {args.target_te:.0%})")
+    mode = "cost-aware" if d.get("cost_aware") else "gross (cost-blind)"
+    print(
+        f"\nPortfolio for '{args.strategy}' as of {args.as_of:%Y-%m-%d} "
+        f"(target TE {args.target_te:.0%}, {mode})"
+    )
     print(
         f"  IR* {d['ir_star']:.2f}  predicted TE {d['predicted_tracking_error']:.1%}  "
         f"predicted IR {d['predicted_ir']:.2f}  transfer coef {d['transfer_coefficient']:.2f}  "
         f"turnover {d['turnover']:.1%}"
     )
+    if d.get("cost_aware"):
+        print(
+            f"  net active return {d['expected_active_return_net']:.2%}/yr  "
+            f"(gross {d['expected_active_return']:.2%} − cost {d['cost_drag']:.2%}: "
+            f"linear {d['linear_cost']:.2%} + √-impact {d['impact_cost']:.2%})"
+        )
     if "capacity_capital" in d:
         print(
             f"  cost drag {d['cost_drag']:.2%}/yr  capacity ≈ ${d['capacity_capital']:,.0f} "
@@ -903,6 +915,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Dust floor: min weight if held (utility)",
     )
     alloc.add_argument("--benchmark", default="SPY", help="Benchmark for residual vol / beta (utility)")
+    alloc.add_argument(
+        "--gross-objective",
+        dest="gross_objective",
+        action="store_true",
+        help="Cost-blind solve (utility): drop 007's cost from the objective, report it ex-post only. "
+        "Default is cost-aware (name-specific turnover + √-impact in the objective).",
+    )
+    alloc.add_argument(
+        "--holding-period",
+        dest="holding_period",
+        type=float,
+        default=1.0 / 12.0,
+        help="Expected holding period in years, to annualise the in-objective cost (utility; default 1/12)",
+    )
     alloc.set_defaults(func=cmd_allocate)
 
     opt = subparsers.add_parser(

--- a/main.py
+++ b/main.py
@@ -177,6 +177,7 @@ def _allocate_utility(args) -> None:
         min_weight=args.min_weight,
         max_names=args.max_names,
         benchmark=args.benchmark,
+        neutralize_factors=args.neutralize_factors,
         capital=args.capital,
         holding_period_years=args.holding_period,
         cost_aware=not args.gross_objective,
@@ -464,6 +465,7 @@ def cmd_alphas(args) -> None:
                 as_of=args.as_of,
                 benchmark=args.benchmark,
                 neutralize=args.neutralize,
+                neutralize_factors=args.neutralize_factors,
                 lookback_days=args.lookback_days,
             ),
             args,
@@ -480,6 +482,7 @@ def cmd_alphas(args) -> None:
         ic=args.ic,
         benchmark=args.benchmark,
         neutralize=args.neutralize,
+        neutralize_factors=args.neutralize_factors,
         lookback_days=args.lookback_days,
     )
 
@@ -489,6 +492,7 @@ def cmd_alphas(args) -> None:
         "scanner": f"scanner '{args.scanner}' strength",
     }[args.source]
     print(f"\nAlphas from {src_desc} as of {args.as_of:%Y-%m-%d} (IC={args.ic}, benchmark={args.benchmark})")
+    _print_neutralization(result)
     if not result["benchmark_available"]:
         print("  ! benchmark unavailable — residual vol falls back to total volatility")
     if result["low_confidence"]:
@@ -505,6 +509,25 @@ def cmd_alphas(args) -> None:
         )
 
 
+def _print_neutralization(result) -> None:
+    """One honest line about what the alphas were actually regressed against.
+
+    Reports what was *applied* (from the refinement's meta), not what was requested —
+    and warns when a requested factor exposure was unavailable, so "factor-neutral"
+    is never claimed for un-neutralized output.
+    """
+    requested = result.get("neutralize_factors") or []
+    applied = result.get("neutralized_against") or []
+    if applied:
+        print(f"  neutralized against: {', '.join(applied)}")
+    missing = [f for f in requested if f not in applied]
+    if missing:
+        print(
+            f"  ! requested factor(s) NOT neutralized (exposures unavailable — "
+            f"insufficient history?): {', '.join(missing)}"
+        )
+
+
 def _print_combined_alphas(result, args) -> None:
     """Print the multi-signal combination: per-signal weights/ICs + the combined alphas."""
     if not result.get("universe_size"):
@@ -512,6 +535,7 @@ def _print_combined_alphas(result, args) -> None:
         return
 
     print(f"\nCombined alpha from {', '.join(result['signals'])} as of {args.as_of:%Y-%m-%d}")
+    _print_neutralization(result)
     print(f"  measured over {result['n_periods']} rebalances  |  combined IC {result['combined_ic']:.4f}")
     print(f"\n{'SIGNAL':16}{'IC':>9}{'SHRUNK':>9}{'WEIGHT':>9}")
     for sig in result["signals"]:
@@ -589,6 +613,7 @@ def cmd_info(args) -> None:
         source=args.source,
         scanner=args.scanner,
         benchmark=args.benchmark,
+        neutralize_factors=args.neutralize_factors,
         horizon=args.horizon,
         n_trials=args.n_trials,
     )
@@ -640,6 +665,7 @@ def cmd_horizon(args) -> None:
         source=args.source,
         scanner=args.scanner,
         benchmark=args.benchmark,
+        neutralize_factors=args.neutralize_factors,
         max_lag=args.max_lag,
         timeframe=args.timeframe,
     )
@@ -812,6 +838,37 @@ def _symbols(value: str) -> List[str]:
     return [s.strip().upper() for s in value.split(",") if s.strip()]
 
 
+#: The bare-flag default for --neutralize-factors: the risk-control factors.
+#: Momentum is deliberately excluded — a momentum tilt is a return bet the alphas
+#: may intend; regress it out explicitly if that's the goal.
+DEFAULT_NEUTRAL_FACTORS = ["market", "volatility", "size"]
+
+
+def _factors(value: str) -> List[str]:
+    from src.risk.exposures import FACTOR_NAMES
+
+    factors = [s.strip().lower() for s in value.split(",") if s.strip()]
+    unknown = [f for f in factors if f not in FACTOR_NAMES]
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            f"unknown factor(s) {', '.join(unknown)}; available: {', '.join(FACTOR_NAMES)}"
+        )
+    return factors
+
+
+def _add_neutralize_factors_flag(parser, note: str = "") -> None:
+    parser.add_argument(
+        "--neutralize-factors",
+        dest="neutralize_factors",
+        type=_factors,
+        nargs="?",
+        const=DEFAULT_NEUTRAL_FACTORS,
+        default=[],
+        help="Factor-neutral alphas: regress out these risk-model exposures "
+        f"(comma-separated; bare flag = {','.join(DEFAULT_NEUTRAL_FACTORS)} — momentum kept){note}",
+    )
+
+
 def _date(value: str) -> datetime:
     return datetime.strptime(value, "%Y-%m-%d")
 
@@ -925,6 +982,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Dust floor: min weight if held (utility)",
     )
     alloc.add_argument("--benchmark", default="SPY", help="Benchmark for residual vol / beta (utility)")
+    _add_neutralize_factors_flag(alloc, note=" (utility)")
     alloc.add_argument(
         "--gross-objective",
         dest="gross_objective",
@@ -1037,6 +1095,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Make alphas beta-neutral (regress out benchmark beta)",
     )
+    _add_neutralize_factors_flag(alphas)
     alphas.add_argument("--lookback-days", dest="lookback_days", type=int, default=180)
     alphas.set_defaults(func=cmd_alphas)
 
@@ -1061,6 +1120,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Configs tried (for multiple-testing inflation)",
     )
+    _add_neutralize_factors_flag(info, note="; measure the alpha you deploy")
     info.set_defaults(func=cmd_info)
 
     hz = subparsers.add_parser(
@@ -1078,6 +1138,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--max-lag", dest="max_lag", type=int, default=10, help="Largest lag (periods) to measure"
     )
     hz.add_argument("--timeframe", default="1Day")
+    _add_neutralize_factors_flag(hz, note="; measure the alpha you deploy")
     hz.set_defaults(func=cmd_horizon)
 
     risk = subparsers.add_parser(

--- a/main.py
+++ b/main.py
@@ -196,17 +196,27 @@ def _allocate_utility(args) -> None:
         f"predicted IR {d['predicted_ir']:.2f}  transfer coef {d['transfer_coefficient']:.2f}  "
         f"turnover {d['turnover']:.1%}"
     )
-    if d.get("cost_aware"):
+    if "round_trip_cost" in d:
+        # Headline: the conservative round-trip haircut (enter + exit, amortised) - the
+        # same cost model as capacity, so the two agree.
         print(
-            f"  net active return {d['expected_active_return_net']:.2%}/yr  "
-            f"(gross {d['expected_active_return']:.2%} − cost {d['cost_drag']:.2%}: "
-            f"linear {d['linear_cost']:.2%} + √-impact {d['impact_cost']:.2%})"
+            f"  net active return {d['expected_active_return_net']:.2%}/yr (round-trip)  "
+            f"= gross {d['expected_active_return']:.2%} − round-trip cost {d['round_trip_cost']:.2%}"
         )
+        # Detail: the one-way cost of this rebalance's turnover (prior reporting).
+        if d.get("cost_aware"):
+            print(
+                f"    this rebalance: turnover cost {d['cost_drag']:.2%}/yr one-way "
+                f"(linear {d['linear_cost']:.2%} + √-impact {d['impact_cost']:.2%}); "
+                f"one-way net {d['expected_active_return_net_oneway']:.2%}"
+            )
+        else:
+            print(
+                f"    this rebalance: turnover cost {d['cost_drag']:.2%}/yr one-way; "
+                f"one-way net {d['expected_active_return_net_oneway']:.2%}"
+            )
     if "capacity_capital" in d:
-        print(
-            f"  cost drag {d['cost_drag']:.2%}/yr  capacity ≈ ${d['capacity_capital']:,.0f} "
-            f"(where √-impact erases the alpha)"
-        )
+        print(f"  capacity ≈ ${d['capacity_capital']:,.0f} (where √-impact erases the alpha)")
     print(f"\n{'SYMBOL':10}{'WEIGHT':>8}" + (f"{'DOLLARS':>14}{'SHARES':>10}" if result["holdings"] else ""))
     if result["holdings"]:
         for h in result["holdings"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tradeflow"
-version = "0.2.0"
+version = "0.3.0"
 description = "A simple, layered, broker-agnostic algorithmic trading engine (Alpaca adapter included; backtest + live)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/alphas/base.py
+++ b/src/alphas/base.py
@@ -22,6 +22,7 @@ from typing import List
 import pandas as pd
 
 from src.alphas import refine
+from src.data.features import EXPOSURE_PREFIX
 from src.data.panel import FeaturePanel
 
 #: Conservative default information coefficient. The absolute scale of alphas is
@@ -53,6 +54,12 @@ class AlphaContext:
     ic: float = DEFAULT_IC
     default_residual_vol: float = 0.20  # fallback when a name has no risk estimate
     neutralize: bool = False  # regress out the benchmark-beta exposure
+    #: Risk-model factors to regress out (``exp_<name>`` panel columns, written by
+    #: :func:`src.data.features.add_factor_exposure_features`). ``"market"`` here
+    #: supersedes the plain-beta ``neutralize`` (same exposure, standardized).
+    #: Momentum is deliberately absent from the usual set — a momentum tilt is a
+    #: return bet the alphas may intend; market/volatility/size are risk-control.
+    neutralize_factors: tuple = ()
     winsorize_limits: tuple = (0.025, 0.975)
     alpha_cap_std: float = 3.0
     min_universe: int = DEFAULT_MIN_UNIVERSE
@@ -66,7 +73,9 @@ def refine_alpha(
     """Refine a panel's ``score`` column into ``z`` and ``alpha`` columns.
 
     Cross-sectional at this one rebalance: winsorize, z-score, optionally neutralize
-    against the ``beta`` exposure, scale by ``sigma * IC``, then cap. On a thin
+    against the ``beta`` exposure and/or the risk-model factor block
+    (``context.neutralize_factors`` reading ``exp_<factor>`` columns), scale by
+    ``sigma * IC``, then cap. On a thin
     universe (``< context.min_universe`` scored names) winsorize and the unit-std
     scaling are skipped in favour of demean-only, and ``panel.meta['low_confidence']``
     is set. Reads ``residual_vol`` for ``sigma`` (falling back to the context default).
@@ -90,10 +99,33 @@ def refine_alpha(
     else:
         z = refine.zscore(refine.winsorize(s, *context.winsorize_limits))
 
-    # 3. Optional benchmark-beta neutralisation (regress z on the beta exposure).
-    if context.neutralize and not thin and panel.has("beta"):
-        exposures = panel.get("beta").reindex(z.index).to_frame("beta")
-        z = refine.neutralize(z, exposures)
+    # 3. Optional neutralisation: benchmark beta and/or risk-model factor exposures
+    #    (one regression on the union, so the residual is orthogonal to all of it).
+    #    A factor column is used only if it actually varies across covered names —
+    #    an absent, all-NaN, or constant column must degrade to beta neutralisation,
+    #    never silently to *no* neutralisation. Names missing a factor value get the
+    #    cross-sectional mean (0 — exposures are standardized), which keeps them in
+    #    the regression instead of stripping their beta neutralisation too.
+    if not thin:
+        columns = {}
+        imputed = 0
+        for factor in context.neutralize_factors:
+            col = f"{EXPOSURE_PREFIX}{factor}"
+            if not panel.has(col):
+                continue
+            series = panel.get(col).reindex(z.index)
+            if series.notna().sum() >= 2 and series.std(ddof=0) > 0:
+                imputed += int(series.isna().sum())
+                columns[col] = series.fillna(0.0)
+        market_col = f"{EXPOSURE_PREFIX}market"
+        if context.neutralize and panel.has("beta") and market_col not in columns:
+            columns["beta"] = panel.get("beta")
+        if columns:
+            z = refine.neutralize(z, pd.DataFrame(columns).reindex(z.index))
+        panel.meta["neutralized_against"] = [
+            c[len(EXPOSURE_PREFIX):] if c.startswith(EXPOSURE_PREFIX) else c for c in columns
+        ]
+        panel.meta["neutralize_imputed"] = imputed
 
     # 4. Scale to a residual-return forecast via alpha_i = sigma_i * IC * z_i.
     if panel.has("residual_vol"):

--- a/src/alphas/base.py
+++ b/src/alphas/base.py
@@ -123,7 +123,7 @@ def refine_alpha(
         if columns:
             z = refine.neutralize(z, pd.DataFrame(columns).reindex(z.index))
         panel.meta["neutralized_against"] = [
-            c[len(EXPOSURE_PREFIX):] if c.startswith(EXPOSURE_PREFIX) else c for c in columns
+            c[len(EXPOSURE_PREFIX) :] if c.startswith(EXPOSURE_PREFIX) else c for c in columns
         ]
         panel.meta["neutralize_imputed"] = imputed
 

--- a/src/costs/base.py
+++ b/src/costs/base.py
@@ -65,6 +65,26 @@ class CostModel(ABC):
         notional = trade.notional
         return self.cost(trade).total / notional if notional > 0 else 0.0
 
+    def turnover_cost_rate(self, spread: float = None) -> float:
+        """Linear (size-independent) one-way cost per unit of traded notional.
+
+        The size-independent part of a trade's cost — the optimiser's L1 turnover
+        coefficient (Spec 016). A model with no linear cost returns 0 (the default);
+        :class:`~src.costs.parametric.ParametricCostModel` returns commission + s/2.
+        """
+        return 0.0
+
+    def impact_coefficient(self, daily_vol: float, adv_dollar: float, capital: float) -> float:
+        """√-impact coefficient ``k`` for the optimiser's ``Σ kᵢ·|Δwᵢ|^{3/2}`` term.
+
+        The realistic square-root impact is convex in size but not quadratic, so it
+        enters Spec 008's objective as a conic term rather than the risk quadratic.
+        ``k`` is *per unit of capital, per rebalance*: the impact cost as a fraction of
+        capital of trading ``|Δwᵢ|`` (a fraction of the ``capital`` book) is
+        ``k·|Δwᵢ|^{3/2}``. A model with no impact returns 0 (the default).
+        """
+        return 0.0
+
     def carry_cost(self, notional: float, is_short: bool, holding_years: float) -> float:
         """Financing cost of *holding* a position (borrow on shorts). Default: none."""
         return 0.0

--- a/src/costs/parametric.py
+++ b/src/costs/parametric.py
@@ -85,3 +85,20 @@ class ParametricCostModel(CostModel):
         """
         s = self.default_spread if spread is None else spread
         return self.commission_rate + s / 2.0
+
+    def impact_coefficient(self, daily_vol: float, adv_dollar: float, capital: float) -> float:
+        """√-impact coefficient ``k`` (per unit capital) for the optimiser's conic term.
+
+        The √-law impact rate is ``η·σ·√(participation)`` with ``participation =
+        |q|/ADV``. Trading ``|Δw|`` of a ``capital``-dollar book is ``q = |Δw|·capital/p``
+        shares, so ``participation = |Δw|·capital / (p·ADV) = |Δw|·capital / ADV$``. The
+        impact cost as a *fraction of capital* is then ``η·σ·√(capital/ADV$)·|Δw|^{3/2}``,
+        so ``k = η·σ·√(capital/ADV$)``. Zero when ADV is unavailable (mirrors
+        :meth:`cost`, which charges no impact without volume) or in linear-impact mode
+        (that fallback is quadratic-in-size, not conic, and isn't fed to the optimiser).
+        """
+        # `not (x > 0)` (rather than `x <= 0`) also rejects NaN, so a bad ADV/vol input
+        # drops the impact term instead of poisoning the solve with a NaN coefficient.
+        if self.linear_impact or not (adv_dollar > 0) or not (capital > 0) or not (daily_vol > 0):
+            return 0.0
+        return self.impact_eta * daily_vol * math.sqrt(capital / adv_dollar)

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -6,7 +6,7 @@ scans a universe as of a timestamp (leakage-safe), and a :class:`~src.data.panel
 holds every name's features in one table that producers fill and consumers read.
 """
 
-from src.data.features import Scorer, add_risk_features, add_score_feature
+from src.data.features import Scorer, add_factor_exposure_features, add_risk_features, add_score_feature
 from src.data.panel import FeaturePanel
 from src.data.scan import BarSource, ClientBarSource, slice_to_as_of
 from src.data.store import BAR_COLUMNS, ParquetBarStore
@@ -21,6 +21,7 @@ __all__ = [
     "slice_to_as_of",
     "FeaturePanel",
     "Scorer",
+    "add_factor_exposure_features",
     "add_risk_features",
     "add_score_feature",
     "ParquetBarStore",

--- a/src/data/features.py
+++ b/src/data/features.py
@@ -1,14 +1,14 @@
 """Feature producers - populate a :class:`FeaturePanel`'s columns from scanned bars.
 
 Each producer is the cross-sectional analog of an indicator: it reads the
-point-in-time bars for the universe and writes one or more feature columns. Today
-there are two - a risk producer (beta + residual volatility, the seed of a future
-risk model) and a generic score producer (apply any per-name scorer). New
-producers (factor exposures, liquidity, transaction-cost params) slot in the same
-way without the consumers above changing.
+point-in-time bars for the universe and writes one or more feature columns. Three
+today - a risk producer (beta + residual volatility), a factor-exposure producer
+(the risk model's standardized exposures, for factor-neutral alphas), and a
+generic score producer (apply any per-name scorer). New producers (liquidity,
+transaction-cost params) slot in the same way without the consumers changing.
 """
 
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Sequence
 
 import pandas as pd
 
@@ -18,6 +18,9 @@ from src.indicators import indicators
 
 #: A scorer reads one symbol's (as-of-sliced) bars and returns a continuous score.
 Scorer = Callable[[pd.DataFrame], float]
+
+#: Panel column prefix for factor-exposure features (``exp_market``, ``exp_size``, ...).
+EXPOSURE_PREFIX = "exp_"
 
 
 def add_risk_features(
@@ -56,6 +59,36 @@ def add_risk_features(
     panel.set("beta", betas)
     panel.set("residual_vol", vols)
     panel.meta["benchmark_available"] = available
+    return panel
+
+
+def add_factor_exposure_features(
+    panel: FeaturePanel,
+    bars: Dict[str, pd.DataFrame],
+    benchmark_bars: Optional[pd.DataFrame],
+    factors: Sequence[str],
+) -> FeaturePanel:
+    """Write standardized risk-model factor exposures as ``exp_<factor>`` columns.
+
+    The columns come from the same exposure builder the factor risk model uses
+    (:func:`src.risk.exposures.build_factor_exposures`), so "factor-neutral" in the
+    alpha pipeline means neutral to the *risk model's* factors — one definition,
+    both places. The market factor reuses the panel's ``beta`` column when present
+    (same regression, already run by :func:`add_risk_features`). If the build
+    qualifies fewer than two names, **no columns are written** — the refinement then
+    falls back to plain-beta neutralisation rather than silently doing nothing.
+    Names missing a single factor get a NaN exposure (mean-imputed downstream).
+    """
+    from src.risk.exposures import build_factor_exposures
+
+    if not list(factors):
+        return panel
+    betas = panel.get("beta") if panel.has("beta") else None
+    frame = build_factor_exposures(bars, benchmark_bars, factors=list(factors), betas=betas)
+    if frame.empty:
+        return panel
+    for name in frame.columns:
+        panel.set(f"{EXPOSURE_PREFIX}{name}", frame[name])
     return panel
 
 

--- a/src/portfolio/optimizer.py
+++ b/src/portfolio/optimizer.py
@@ -4,19 +4,29 @@ The OR-Tools :class:`~src.portfolio.allocator.PortfolioAllocator` maximises a sc
 score subject to constraints - it has no notion of risk, so it piles weight onto the
 highest-scoring names regardless of how correlated they are. Active-management
 construction instead maximises a **risk-adjusted utility**, trading expected residual
-return (alpha, Spec 005) against active risk (covariance, Spec 006):
+return (alpha, Spec 005) against active risk (covariance, Spec 006) - and, once cost is
+in the objective (Spec 016), against the *name-specific* cost of getting there:
 
-    U(w) = αᵀw − λ_A · wᵀΣw            (long-only absolute: benchmark w_B = 0)
+    U(w) = αᵀw − λ_A · wᵀΣw − Σᵢ cᵢ·|Δwᵢ| − Σᵢ kᵢ·|Δwᵢ|^{3/2}      (Δw = w − w₀)
+           └ value ┘  └ active risk ┘  └ linear turnover ┘  └ √-impact (conic) ┘
 
 The output is the portfolio that maximises the *information ratio you can actually
-implement*, plus the Fundamental-Law diagnostics that make the cost of every
-constraint visible. This is **research-clock**: it proposes target weights (a config a
-human promotes), it never places an order - so it lives apart from the operational
-position sizer.
+implement net of cost*, plus the Fundamental-Law diagnostics that make the cost of
+every constraint visible. This is **research-clock**: it proposes target weights (a
+config a human promotes), it never places an order - so it lives apart from the
+operational position sizer.
 
-Pure numpy: the unconstrained optimum is closed-form; the constrained (long-only, box,
-budget, cardinality) optimum is a small convex QP solved by projected gradient with a
-capped-simplex projection - no heavyweight QP dependency.
+Pure numpy - no heavyweight QP/conic dependency. The unconstrained cost-free optimum is
+closed-form; the constrained problem (long-only, box, budget, cardinality) is a small
+convex program solved by **proximal gradient**. The cost term is nonsmooth but convex,
+so it enters through the proximal step: after each gradient step on the smooth part we
+apply the exact proximal operator of ``cᵢ·|Δwᵢ| + kᵢ·|Δwᵢ|^{3/2}`` *composed with* the
+capped-simplex projection. That proximal operator is separable per name given a single
+budget dual, and each coordinate has a closed form (a soft-threshold *around w₀* for the
+linear cost; a quadratic-in-√ root for the √-impact) - so the whole conic problem is
+solved by the same 1-D budget bisection the cost-free projection already used, with no
+external solver. When ``cᵢ = kᵢ = 0`` it reduces *exactly* to the cost-free projected
+gradient, so Spec 008's behaviour is unchanged.
 """
 
 from dataclasses import dataclass, field
@@ -25,7 +35,23 @@ from typing import Dict, List, Optional
 import numpy as np
 
 from src.alphas.base import Alpha
+from src.costs.base import CostModel
 from src.risk.base import RiskMatrix
+
+
+@dataclass
+class CostInputs:
+    """Per-name, as-of liquidity context the cost model prices trades against.
+
+    Threaded from Spec 007: a fractional ``spread`` (quoted, or a high-low-range proxy),
+    trailing ``adv_dollar`` (ADV in dollars = price · share-ADV), and trailing
+    ``daily_vol`` (daily return volatility). All keyed by symbol; missing names fall
+    back to the cost model's defaults (spread) or drop the √-impact term (ADV/vol).
+    """
+
+    spread: Dict[str, float] = field(default_factory=dict)
+    adv_dollar: Dict[str, float] = field(default_factory=dict)
+    daily_vol: Dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -40,7 +66,7 @@ class PortfolioResult:
 
 
 class MeanVarianceOptimizer:
-    """Maximise ``αᵀw − λ·wᵀΣw`` over long-only, box-bounded, budgeted weights."""
+    """Maximise ``αᵀw − λ·wᵀΣw − cost(w − w₀)`` over long-only, box, budgeted weights."""
 
     def __init__(
         self,
@@ -58,6 +84,8 @@ class MeanVarianceOptimizer:
         self.max_weight = max_weight
         self.min_weight = min_weight  # minimum weight for a *held* name (a dust floor)
         self.max_names = max_names
+        # Manual override retained for backward-compat / the cost-free case; when a cost
+        # model is supplied the no-trade band *emerges* from the cost (see optimize()).
         self.no_trade_band = no_trade_band
         self.max_iter = max_iter
         self.tol = tol
@@ -70,14 +98,28 @@ class MeanVarianceOptimizer:
         target_te: Optional[float] = None,
         risk_aversion: Optional[float] = None,
         current_weights: Optional[Dict[str, float]] = None,
+        cost_model: Optional[CostModel] = None,
+        cost_inputs: Optional[CostInputs] = None,
+        capital: Optional[float] = None,
+        holding_period_years: float = 1.0 / 12.0,
     ) -> PortfolioResult:
         """Construct the utility-maximising portfolio over the alpha/risk universe.
 
         Supply *either* ``target_te`` (the intuitive knob - "run at 4% tracking
-        error") *or* ``risk_aversion`` (``λ_A`` directly). ``current_weights`` (``w_0``)
-        is where turnover is measured from. Returns the weights, the diagnostics
-        (``IR*``, predicted TE/IR, transfer coefficient, value added, turnover), and a
-        feasibility verdict naming the binding constraint when infeasible.
+        error") *or* ``risk_aversion`` (``λ_A`` directly). ``current_weights`` (``w₀``)
+        is where turnover is measured from.
+
+        Pass a ``cost_model`` + ``cost_inputs`` to make the solve **cost-aware** (Spec
+        016): the objective gains a name-specific linear turnover penalty and, when
+        ``capital`` is given, the √-impact term. Cost coefficients are *annualised* to
+        the same units as the (annualised) alpha by dividing the one-way rate by
+        ``holding_period_years`` - matching Spec 007's alpha-haircut and the ex-post
+        cost drag. Without a cost model the solve is cost-blind (Spec 008, unchanged).
+
+        Returns the weights, the diagnostics (``IR*``, predicted TE/IR, transfer
+        coefficient, value added, turnover, and - when cost-aware - the linear/impact
+        cost split and net expected return), and a feasibility verdict naming the
+        binding constraint when infeasible.
         """
         symbols, alpha = self._align(alphas, risk)
         if len(symbols) == 0:
@@ -87,12 +129,12 @@ class MeanVarianceOptimizer:
         n = len(symbols)
 
         # Cardinality + box can make the budget unreachable: name the binding bound.
-        k = min(self.max_names or n, n)
-        if k * self.max_weight < 1.0 - 1e-9:
+        k_cap = min(self.max_names or n, n)
+        if k_cap * self.max_weight < 1.0 - 1e-9:
             return PortfolioResult(
                 weights={},
                 feasible=False,
-                binding_constraint=f"max_weight*{k} < 1 (cardinality/weight cap can't fund the book)",
+                binding_constraint=f"max_weight*{k_cap} < 1 (cardinality/weight cap can't fund the book)",
             )
 
         sigma_inv = np.linalg.inv(sigma)
@@ -101,14 +143,23 @@ class MeanVarianceOptimizer:
         lam = self._risk_aversion(ir_star, target_te, risk_aversion)
         unconstrained = (sigma_inv @ alpha) / (2.0 * lam)
 
-        w = self._constrained_solve(alpha, sigma, lam, n)
-
         w0 = self._vector(current_weights or {}, symbols)
-        # No-trade band: if every name moves less than the band, don't churn.
+        # Per-name cost coefficients (annualised), aligned to `symbols`. Both zero when
+        # cost-blind -> the solve reduces exactly to Spec 008's projected gradient.
+        c_lin, k_imp = self._cost_coefficients(
+            cost_model, cost_inputs, capital, holding_period_years, symbols
+        )
+        cost_aware = bool(np.any(c_lin > 0) or np.any(k_imp > 0))
+
+        w = self._constrained_solve(alpha, sigma, lam, n, c_lin, k_imp, w0)
+
+        # Manual no-trade band (cost-free override): if every name moves less than the
+        # band, don't churn. When cost-aware the band instead *emerges* from c_lin (a
+        # name stays at w₀ⁱ while its marginal value is inside ±cᵢ), so this is a no-op.
         if self.no_trade_band > 0 and np.max(np.abs(w - w0)) < self.no_trade_band:
             w = w0.copy()
 
-        diagnostics = self._diagnostics(alpha, sigma, w, w0, lam, ir_star)
+        diagnostics = self._diagnostics(alpha, sigma, w, w0, lam, ir_star, c_lin, k_imp, cost_aware)
         return PortfolioResult(
             weights={s: float(w[i]) for i, s in enumerate(symbols) if w[i] > 1e-9},
             feasible=True,
@@ -117,23 +168,57 @@ class MeanVarianceOptimizer:
         )
 
     # ------------------------------------------------------------------ #
+    # Cost coefficients
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _cost_coefficients(cost_model, cost_inputs, capital, holding_period_years, symbols):
+        """Build the annualised per-name linear (``cᵢ``) and √-impact (``kᵢ``) vectors.
+
+        ``cᵢ = turnover_cost_rate(spreadᵢ) / h`` (one-way commission+half-spread, per
+        year); ``kᵢ = impact_coefficient(σᵢ, ADV$ᵢ, capital) / h`` (per year), and
+        ``kᵢ = 0`` when ``capital`` is absent - the "ship linear first" default. Zero
+        vectors when no cost model is supplied.
+        """
+        n = len(symbols)
+        c_lin = np.zeros(n)
+        k_imp = np.zeros(n)
+        if cost_model is None or cost_inputs is None:
+            return c_lin, k_imp
+        h = max(holding_period_years, 1e-9)
+        have_capital = capital is not None and capital > 0
+        for i, s in enumerate(symbols):
+            spread = cost_inputs.spread.get(s)
+            c_lin[i] = cost_model.turnover_cost_rate(spread) / h
+            if have_capital:
+                adv_dollar = cost_inputs.adv_dollar.get(s, 0.0)
+                daily_vol = cost_inputs.daily_vol.get(s, 0.0)
+                k_imp[i] = cost_model.impact_coefficient(daily_vol, adv_dollar, capital) / h
+        # A non-finite input (e.g. a NaN spread proxy) must drop that name's cost term,
+        # not poison the whole solve with a NaN coefficient (which would empty the book).
+        c_lin = np.where(np.isfinite(c_lin), c_lin, 0.0)
+        k_imp = np.where(np.isfinite(k_imp), k_imp, 0.0)
+        return c_lin, k_imp
+
+    # ------------------------------------------------------------------ #
     # Solve
     # ------------------------------------------------------------------ #
-    def _constrained_solve(self, alpha: np.ndarray, sigma: np.ndarray, lam: float, n: int) -> np.ndarray:
-        """Box+budget QP, plus the two non-convex constraints handled by re-solving.
+    def _constrained_solve(self, alpha, sigma, lam, n, c_lin, k_imp, w0) -> np.ndarray:
+        """Box+budget convex program, plus the two non-convex constraints by re-solving.
 
         Cardinality (``‖w‖₀ ≤ max_names``) and the semi-continuous dust floor
         (``w ∈ {0} ∪ [min_weight, max_weight]``) are both non-convex, so each is
-        enforced the same pragmatic way: solve the convex QP, drop the offending
-        names (the smallest beyond the cardinality cap, or any stuck in the
-        ``(0, min_weight)`` hole), and re-solve on the survivors until stable.
+        enforced the same pragmatic way: solve the convex (now cost-aware) program, drop
+        the offending names (the smallest beyond the cardinality cap, or any stuck in
+        the ``(0, min_weight)`` hole), and re-solve on the survivors until stable. A
+        dropped held name is a full liquidation of ``w₀ⁱ``; its cost is captured in the
+        final diagnostics, which price ``w − w₀`` over the full universe.
         """
         active = np.arange(n)
-        w = self._solve(alpha, sigma, lam, active)
+        w = self._solve(alpha, sigma, lam, active, c_lin, k_imp, w0)
 
         if self.max_names is not None and int(np.sum(w > 1e-9)) > self.max_names:
             active = np.argsort(w)[::-1][: self.max_names]
-            w = self._solve(alpha, sigma, lam, active)
+            w = self._solve(alpha, sigma, lam, active, c_lin, k_imp, w0)
 
         # Dust floor: drop held names below min_weight and re-solve, while the budget
         # stays fundable (enough remaining names at max_weight to reach 1).
@@ -144,20 +229,35 @@ class MeanVarianceOptimizer:
                 break  # every held name clears the floor
             if len(keep) == 0 or len(keep) * self.max_weight < 1.0 - 1e-9:
                 break  # dropping further would make the budget infeasible
-            w = self._solve(alpha, sigma, lam, keep)
+            w = self._solve(alpha, sigma, lam, keep, c_lin, k_imp, w0)
         return w
 
-    def _solve(self, alpha: np.ndarray, sigma: np.ndarray, lam: float, active: np.ndarray) -> np.ndarray:
-        """Projected-gradient QP over the active names; full-length weight vector out."""
+    def _solve(self, alpha, sigma, lam, active, c_lin, k_imp, w0) -> np.ndarray:
+        """Proximal-gradient solve over the active names; full-length weight vector out.
+
+        Minimises ``f(w) + g(w)`` with smooth ``f = −αᵀw + λwᵀΣw`` and nonsmooth convex
+        ``g = Σ cᵢ|wᵢ−w₀ⁱ| + Σ kᵢ|wᵢ−w₀ⁱ|^{3/2} + ι_{box∩budget}``. Each iteration is a
+        gradient step on ``f`` followed by the exact proximal operator of ``g`` (see
+        :meth:`_prox_project`). Step ``1/L`` with ``L = 2λ·λmax(Σ)`` guarantees
+        convergence; ``λmin(Σ) > 0`` makes ``f`` strongly convex, so it is linear.
+        """
         n = len(alpha)
-        a, s = alpha[active], sigma[np.ix_(active, active)]
+        a = alpha[active]
+        s = sigma[np.ix_(active, active)]
+        c = c_lin[active]
+        k = k_imp[active]
+        w0a = w0[active]
         # Lipschitz constant of ∇f = -a + 2λ·s·w is 2λ·λmax(s); step = 1/L.
         lmax = float(np.linalg.eigvalsh(s).max())
         step = 1.0 / (2.0 * lam * lmax) if lmax > 0 else 1.0
-        w = self._project(np.ones(len(active)) / len(active))
+        thr = step * c
+        kthr = step * k
+        # Warm-start from w₀ (projected) when it holds weight, else uniform.
+        start = w0a if w0a.sum() > 1e-9 else np.ones(len(active)) / len(active)
+        w = self._prox_project(start, np.zeros_like(thr), np.zeros_like(kthr), w0a)
         for _ in range(self.max_iter):
             grad = -a + 2.0 * lam * (s @ w)
-            nxt = self._project(w - step * grad)
+            nxt = self._prox_project(w - step * grad, thr, kthr, w0a)
             if np.max(np.abs(nxt - w)) < self.tol:
                 w = nxt
                 break
@@ -166,18 +266,59 @@ class MeanVarianceOptimizer:
         full[active] = w
         return full
 
-    def _project(self, y: np.ndarray) -> np.ndarray:
-        """Euclidean projection onto {0 ≤ w ≤ max_weight, Σw = 1} (capped simplex)."""
-        c, target = self.max_weight, 1.0
-        lo, hi = float(y.min() - c), float(y.max())
+    def _prox_project(self, y: np.ndarray, thr: np.ndarray, kthr: np.ndarray, w0: np.ndarray) -> np.ndarray:
+        """Exact prox of the cost + capped-simplex indicator, via a budget bisection.
+
+        Solves ``argmin_w ½‖w−y‖² + Σ thrᵢ|wᵢ−w₀ⁱ| + Σ kthrᵢ|wᵢ−w₀ⁱ|^{3/2}`` over
+        ``{0 ≤ w ≤ cap, Σw = 1}``. With a single dual ``τ`` for the budget it separates
+        per coordinate: ``wᵢ(τ) = clip(w₀ⁱ + d*((yᵢ−τ)−w₀ⁱ), 0, cap)`` where ``d*`` is
+        the per-name proximal step (:meth:`_prox_step`). Each ``wᵢ(τ)`` is monotone
+        non-increasing in ``τ``, so ``Σwᵢ(τ) = 1`` is found by bisection - the same
+        1-D structure the cost-free projection used. With ``thr = kthr = 0`` the
+        coordinate map is ``clip(yᵢ − τ, 0, cap)`` and this is exactly that projection.
+        """
+        cap = self.max_weight
+
+        def total(tau: float) -> float:
+            m = (y - tau) - w0
+            return float(np.clip(w0 + self._prox_step(m, thr, kthr), 0.0, cap).sum())
+
+        pad = float(thr.max()) if thr.size else 0.0
+        lo = float(y.min() - cap - pad)
+        hi = float(y.max() + pad)
+        # Guarantee the budget root is bracketed (total is monotone non-increasing in τ).
+        guard = 0
+        while total(lo) < 1.0 and guard < 200:
+            lo -= abs(lo) + 1.0
+            guard += 1
+        guard = 0
+        while total(hi) > 1.0 and guard < 200:
+            hi += abs(hi) + 1.0
+            guard += 1
         for _ in range(100):
             tau = 0.5 * (lo + hi)
-            total = np.clip(y - tau, 0.0, c).sum()
-            if total > target:
+            if total(tau) > 1.0:
                 lo = tau
             else:
                 hi = tau
-        return np.clip(y - 0.5 * (lo + hi), 0.0, c)
+        tau = 0.5 * (lo + hi)
+        m = (y - tau) - w0
+        return np.clip(w0 + self._prox_step(m, thr, kthr), 0.0, cap)
+
+    @staticmethod
+    def _prox_step(m: np.ndarray, thr: np.ndarray, kthr: np.ndarray) -> np.ndarray:
+        """Per-name trade ``d* = argmin_d ½(d−m)² + thr|d| + kthr|d|^{3/2}`` (unclipped).
+
+        Closed form: ``d* = 0`` when ``|m| ≤ thr`` (the emergent no-trade band - a name
+        is untraded while its move is inside the linear cost); otherwise, with residual
+        ``r = |m| − thr`` and ``b = 3·kthr/2``, the magnitude solves ``u² + b·u = r``
+        (``u = √|d|``), i.e. ``u = (−b + √(b² + 4r))/2`` and ``d* = sign(m)·u²``. With
+        ``kthr = 0`` this is the ordinary soft-threshold ``sign(m)·max(|m|−thr, 0)``.
+        """
+        residual = np.maximum(np.abs(m) - thr, 0.0)
+        b = 1.5 * kthr
+        u = (-b + np.sqrt(b * b + 4.0 * residual)) / 2.0
+        return np.sign(m) * u * u
 
     # ------------------------------------------------------------------ #
     # Calibration & diagnostics
@@ -189,25 +330,41 @@ class MeanVarianceOptimizer:
             return ir_star / (2.0 * target_te)  # λ_A = IR* / (2·ψ_target)
         return 1.0  # neutral default when neither is usable
 
-    def _diagnostics(self, alpha, sigma, w, w0, lam, ir_star) -> Dict[str, float]:
+    def _diagnostics(self, alpha, sigma, w, w0, lam, ir_star, c_lin, k_imp, cost_aware) -> Dict[str, float]:
         sig_w = sigma @ w
         active_variance = float(w @ sig_w)
         te = float(np.sqrt(max(active_variance, 0.0)))
         expected = float(alpha @ w)
         # Transfer coefficient: corr(α, Σ-adjusted active weights) ∈ [-1, 1].
         tc = self._corr(alpha, sig_w)
-        return {
+        dw = w - w0
+        diagnostics = {
             "ir_star": ir_star,
             "risk_aversion": float(lam),
             "expected_active_return": expected,
-            "predicted_tracking_error": te,
+            "predicted_tracking_error": te,  # realised TE at the (cost-bent) optimum
             "predicted_ir": expected / te if te > 0 else 0.0,
             "transfer_coefficient": tc,
             "ir_achieved": tc * ir_star,
             "optimal_tracking_error": ir_star / (2.0 * lam) if lam > 0 else 0.0,
             "value_added": (ir_star**2) / (4.0 * lam) if lam > 0 else 0.0,
-            "turnover": float(np.sum(np.abs(w - w0))),
+            "turnover": float(np.sum(np.abs(dw))),
         }
+        if cost_aware:
+            linear_cost = float(np.sum(c_lin * np.abs(dw)))
+            impact_cost = float(np.sum(k_imp * np.abs(dw) ** 1.5))
+            total_cost = linear_cost + impact_cost
+            diagnostics.update(
+                {
+                    "cost_aware": True,
+                    "linear_cost": linear_cost,  # annualised Σ cᵢ|Δwᵢ| (turnover cost)
+                    "impact_cost": impact_cost,  # annualised Σ kᵢ|Δwᵢ|^{3/2} (√-impact)
+                    "cost_drag": total_cost,
+                    "expected_active_return_net": expected - total_cost,
+                    "names_traded": int(np.sum(np.abs(dw) > 1e-9)),
+                }
+            )
+        return diagnostics
 
     # ------------------------------------------------------------------ #
     # Alignment helpers

--- a/src/portfolio/optimizer.py
+++ b/src/portfolio/optimizer.py
@@ -351,16 +351,26 @@ class MeanVarianceOptimizer:
             "turnover": float(np.sum(np.abs(dw))),
         }
         if cost_aware:
+            # One-way cost of *this rebalance's* turnover - what the objective charged,
+            # kept for continuity with the prior (pre-016) ex-post drag. Detail.
             linear_cost = float(np.sum(c_lin * np.abs(dw)))
             impact_cost = float(np.sum(k_imp * np.abs(dw) ** 1.5))
-            total_cost = linear_cost + impact_cost
+            rebalance_cost = linear_cost + impact_cost
+            # Round-trip haircut on the *held book* (007 §3.2 / the capacity convention):
+            # entering AND exiting each position, amortised over the holding period. This
+            # is the conservative headline net figure - the same cost model _capacity
+            # prices, so the net return and the capacity number agree.
+            book = np.abs(w)
+            round_trip_cost = float(2.0 * (np.sum(c_lin * book) + np.sum(k_imp * book**1.5)))
             diagnostics.update(
                 {
                     "cost_aware": True,
-                    "linear_cost": linear_cost,  # annualised Σ cᵢ|Δwᵢ| (turnover cost)
-                    "impact_cost": impact_cost,  # annualised Σ kᵢ|Δwᵢ|^{3/2} (√-impact)
-                    "cost_drag": total_cost,
-                    "expected_active_return_net": expected - total_cost,
+                    "linear_cost": linear_cost,  # one-way Σ cᵢ|Δwᵢ| (rebalance turnover)
+                    "impact_cost": impact_cost,  # one-way Σ kᵢ|Δwᵢ|^{3/2} (rebalance √-impact)
+                    "cost_drag": rebalance_cost,  # one-way rebalance total (continuity)
+                    "round_trip_cost": round_trip_cost,  # round-trip book haircut (headline)
+                    "expected_active_return_net": expected - round_trip_cost,  # headline: round-trip
+                    "expected_active_return_net_oneway": expected - rebalance_cost,  # detail: one-way
                     "names_traded": int(np.sum(np.abs(dw) > 1e-9)),
                 }
             )

--- a/src/risk/exposures.py
+++ b/src/risk/exposures.py
@@ -14,7 +14,7 @@ factors are on a comparable scale and the factor-return regression is well-posed
 """
 
 from datetime import datetime
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -32,27 +32,53 @@ def build_factor_exposures(
     momentum_skip: int = 21,
     vol_window: int = 60,
     as_of: Optional[datetime] = None,
+    factors: Optional[List[str]] = None,
+    betas: Optional[pd.Series] = None,
 ) -> pd.DataFrame:
     """Build the cross-sectionally standardized exposure matrix ``X`` (symbols × factors).
 
-    Names without enough history for every factor are dropped (the cross-section just
-    has fewer names). Returns an empty frame if fewer than two names qualify.
+    Names without enough history for every requested factor are dropped (the
+    cross-section just has fewer names). Returns an empty frame if fewer than two
+    names qualify. ``factors`` selects a subset of :data:`FACTOR_NAMES` (default:
+    all); the history requirement adapts — momentum needs the longest window, so a
+    subset without it keeps names a full build would drop. ``betas`` supplies
+    precomputed per-name betas for the market factor (a Series by symbol), skipping
+    the per-name regression when the caller already ran it.
     """
+    wanted = list(FACTOR_NAMES) if factors is None else list(factors)
+    unknown = [f for f in wanted if f not in FACTOR_NAMES]
+    if unknown:
+        raise ValueError(f"unknown factors {unknown}; available: {FACTOR_NAMES}")
+    if not wanted:
+        return pd.DataFrame()
+
+    min_bars = momentum_window + momentum_skip + 1 if "momentum" in wanted else vol_window + 1
     bench_close = benchmark_bars["close"] if benchmark_bars is not None and not benchmark_bars.empty else None
     rows: Dict[str, Dict[str, float]] = {}
     for symbol, frame in bars.items():
-        if frame is None or len(frame) < momentum_window + momentum_skip + 1:
+        if frame is None or len(frame) < min_bars:
             continue
         close = frame["close"]
-        returns = close.pct_change().dropna()
-        beta = indicators.calculate_beta(close, bench_close) if bench_close is not None else 1.0
-        momentum = close.iloc[-1 - momentum_skip] / close.iloc[-1 - momentum_skip - momentum_window] - 1.0
-        volatility = float(returns.tail(vol_window).std())
-        dollar_volume = float(close.iloc[-1] * frame["volume"].tail(vol_window).mean())
-        size = np.log(dollar_volume) if dollar_volume > 0 else np.nan
-        rows[symbol] = {"market": beta, "momentum": momentum, "volatility": volatility, "size": size}
+        row: Dict[str, float] = {}
+        if "market" in wanted:
+            known = betas.get(symbol) if betas is not None else None
+            if known is not None and known == known:  # not None, not NaN
+                row["market"] = float(known)
+            elif bench_close is not None:
+                row["market"] = indicators.calculate_beta(close, bench_close)
+            else:
+                row["market"] = 1.0
+        if "momentum" in wanted:
+            row["momentum"] = close.iloc[-1 - momentum_skip] / close.iloc[-1 - momentum_skip - momentum_window] - 1.0
+        if "volatility" in wanted:
+            returns = close.tail(vol_window + 1).pct_change().dropna()
+            row["volatility"] = float(returns.std())
+        if "size" in wanted:
+            dollar_volume = float(close.iloc[-1] * frame["volume"].tail(vol_window).mean())
+            row["size"] = np.log(dollar_volume) if dollar_volume > 0 else np.nan
+        rows[symbol] = row
 
-    frame = pd.DataFrame.from_dict(rows, orient="index").reindex(columns=FACTOR_NAMES).dropna()
+    frame = pd.DataFrame.from_dict(rows, orient="index").reindex(columns=wanted).dropna()
     if len(frame) < 2:
         return frame.iloc[0:0]
     # Cross-sectional z-score per factor (unit dispersion, mean 0).

--- a/src/risk/exposures.py
+++ b/src/risk/exposures.py
@@ -69,7 +69,9 @@ def build_factor_exposures(
             else:
                 row["market"] = 1.0
         if "momentum" in wanted:
-            row["momentum"] = close.iloc[-1 - momentum_skip] / close.iloc[-1 - momentum_skip - momentum_window] - 1.0
+            row["momentum"] = (
+                close.iloc[-1 - momentum_skip] / close.iloc[-1 - momentum_skip - momentum_window] - 1.0
+            )
         if "volatility" in wanted:
             returns = close.tail(vol_window + 1).pct_change().dropna()
             row["volatility"] = float(returns.std())

--- a/src/services/analysis.py
+++ b/src/services/analysis.py
@@ -949,14 +949,18 @@ def construct_portfolio(
 
     if result.feasible:
         if not result.diagnostics.get("cost_aware"):
-            # Cost-blind (gross) objective: still report the ex-post drag so the net
-            # figure is visible - the honest haircut on a cost-blind solve.
+            # Cost-blind (gross) objective: still report the ex-post drag so the net figure
+            # is visible. Same convention as the cost-aware path - a round-trip haircut on
+            # the book for the headline (matching capacity), one-way rebalance drag in detail.
+            h = max(holding_period_years, 1e-9)
             rate = cost_model.turnover_cost_rate()
-            cost_drag = result.diagnostics["turnover"] * rate / max(holding_period_years, 1e-9)
-            result.diagnostics["cost_drag"] = cost_drag
-            result.diagnostics["expected_active_return_net"] = (
-                result.diagnostics["expected_active_return"] - cost_drag
-            )
+            expected = result.diagnostics["expected_active_return"]
+            one_way = result.diagnostics["turnover"] * rate / h
+            round_trip = 2.0 * rate * sum(result.weights.values()) / h
+            result.diagnostics["cost_drag"] = one_way
+            result.diagnostics["round_trip_cost"] = round_trip
+            result.diagnostics["expected_active_return_net"] = expected - round_trip
+            result.diagnostics["expected_active_return_net_oneway"] = expected - one_way
         # Capacity: the capital at which √-impact cost erases the gross alpha.
         result.diagnostics["capacity_capital"] = _capacity(
             result.weights, universe_bars, result.diagnostics["expected_active_return"], holding_period_years

--- a/src/services/analysis.py
+++ b/src/services/analysis.py
@@ -875,16 +875,24 @@ def construct_portfolio(
     capital: Optional[float] = None,
     current_weights: Optional[Dict[str, float]] = None,
     holding_period_years: float = 1.0 / 12.0,
+    cost_aware: bool = True,
 ) -> Dict[str, Any]:
     """Construct the utility-maximising portfolio from alphas (005) and Σ (006).
 
     Read-only research-clock flow: scans the universe as of ``as_of``, builds
     benchmark-neutral alphas and an annualised covariance Σ, then maximises
-    ``αᵀw − λ·wᵀΣw`` over long-only, box-bounded, budgeted (and optionally
-    cardinality-capped) weights, calibrating ``λ`` to ``target_te``. Returns the
-    proposed weights plus the Fundamental-Law report (IR*, predicted TE/IR, transfer
-    coefficient, turnover). This is a **proposal** - it places no orders.
+    ``αᵀw − λ·wᵀΣw − cost(w − w₀)`` over long-only, box-bounded, budgeted (and
+    optionally cardinality-capped) weights, calibrating ``λ`` to ``target_te``.
+
+    With ``cost_aware`` (default) the objective carries 007's cost (Spec 016):
+    name-specific linear turnover (commission + a high-low-range spread proxy) and,
+    when ``capital`` is set, the √-impact term - so the optimiser trades a name's
+    alpha against *that name's* cost and a no-trade band emerges from the cost itself.
+    ``cost_aware=False`` recovers the cost-blind (gross) solve with an ex-post drag.
+    Returns the proposed weights plus the Fundamental-Law report (IR*, predicted TE/IR,
+    transfer coefficient, turnover, cost split). This is a **proposal** - no orders.
     """
+    from src.costs import ParametricCostModel
     from src.portfolio.optimizer import MeanVarianceOptimizer
 
     run_id = new_run_id()
@@ -922,20 +930,33 @@ def construct_portfolio(
             "note": "Insufficient data for alphas and/or a covariance matrix.",
         }
 
+    cost_model = ParametricCostModel()
+    # Per-name, as-of liquidity context (spread proxy, ADV$, daily vol) priced by the
+    # same cost model the backtest uses - the optimiser and backtest share one model.
+    cost_inputs = _cost_inputs(universe_bars, cost_model) if cost_aware else None
+
     optimizer = MeanVarianceOptimizer(max_weight=max_weight, min_weight=min_weight, max_names=max_names)
-    result = optimizer.optimize(alphas, matrix, target_te=target_te, current_weights=current_weights)
+    result = optimizer.optimize(
+        alphas,
+        matrix,
+        target_te=target_te,
+        current_weights=current_weights,
+        cost_model=cost_model if cost_aware else None,
+        cost_inputs=cost_inputs,
+        capital=capital,
+        holding_period_years=holding_period_years,
+    )
 
-    # Ex-post cost drag: the proposed turnover priced through the linear cost rate,
-    # amortized over the holding period (a haircut on the expected active return).
     if result.feasible:
-        from src.costs import ParametricCostModel
-
-        rate = ParametricCostModel().turnover_cost_rate()
-        cost_drag = result.diagnostics["turnover"] * rate / max(holding_period_years, 1e-9)
-        result.diagnostics["cost_drag"] = cost_drag
-        result.diagnostics["expected_active_return_net"] = (
-            result.diagnostics["expected_active_return"] - cost_drag
-        )
+        if not result.diagnostics.get("cost_aware"):
+            # Cost-blind (gross) objective: still report the ex-post drag so the net
+            # figure is visible - the honest haircut on a cost-blind solve.
+            rate = cost_model.turnover_cost_rate()
+            cost_drag = result.diagnostics["turnover"] * rate / max(holding_period_years, 1e-9)
+            result.diagnostics["cost_drag"] = cost_drag
+            result.diagnostics["expected_active_return_net"] = (
+                result.diagnostics["expected_active_return"] - cost_drag
+            )
         # Capacity: the capital at which √-impact cost erases the gross alpha.
         result.diagnostics["capacity_capital"] = _capacity(
             result.weights, universe_bars, result.diagnostics["expected_active_return"], holding_period_years
@@ -982,6 +1003,50 @@ def construct_portfolio(
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+#: The bar feed carries no quotes, so the effective spread is proxied as this fraction
+#: of the trailing daily high-low range (a rough liquidity signal), then clamped.
+SPREAD_RANGE_FRACTION = 0.10
+_COST_WINDOW = 20  # trailing bars for the ADV / vol / spread estimates (matches the backtest)
+
+
+def _spread_proxy(frame, cost_model, window: int = _COST_WINDOW) -> float:
+    """Per-name fractional spread from the trailing high-low range, clamped.
+
+    Effective spread ≈ ``SPREAD_RANGE_FRACTION`` of the median daily range, floored at
+    a fraction of the model default (so very liquid names can price below it) and capped
+    at 2%. Falls back to the model default when OHLC is missing - an honest proxy, not a
+    quote.
+    """
+    if not {"high", "low", "close"} <= set(frame.columns) or len(frame) < 2:
+        return cost_model.default_spread
+    rng = ((frame["high"] - frame["low"]) / frame["close"]).tail(window)
+    proxy = float(rng.median()) * SPREAD_RANGE_FRACTION
+    if not np.isfinite(proxy):
+        return cost_model.default_spread
+    return float(min(max(proxy, cost_model.default_spread * 0.2), 0.02))
+
+
+def _cost_inputs(universe_bars, cost_model, window: int = _COST_WINDOW):
+    """Per-name as-of liquidity context (spread proxy, ADV$, daily vol) for the solve.
+
+    Trailing windows only, so nothing depends on post-``as_of`` bars (the same leakage
+    discipline as the backtest's cost inputs and :func:`_capacity`).
+    """
+    from src.portfolio.optimizer import CostInputs
+
+    spread, adv_dollar, daily_vol = {}, {}, {}
+    for sym, frame in universe_bars.items():
+        if frame is None or len(frame) < 2:
+            continue
+        price = float(frame["close"].iloc[-1])
+        adv_shares = float(frame["volume"].tail(window).mean()) if "volume" in frame else 0.0
+        spread[sym] = _spread_proxy(frame, cost_model, window)
+        adv_dollar[sym] = price * adv_shares
+        vol = float(frame["close"].pct_change().tail(window).std())
+        daily_vol[sym] = vol if np.isfinite(vol) else 0.0
+    return CostInputs(spread=spread, adv_dollar=adv_dollar, daily_vol=daily_vol)
+
+
 def _capacity(weights, universe_bars, gross_alpha, holding_period_years) -> float:
     """Capital at which √-impact cost erases the gross alpha (net active return → 0).
 

--- a/src/services/analysis.py
+++ b/src/services/analysis.py
@@ -579,9 +579,7 @@ def compute_information(
         "signal": lambda: signal_scorer(strat),
         "scanner": lambda: scanner_scorer(_scanner(scanner)),
     }[source]()
-    ctx = AlphaContext(
-        ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors)
-    )
+    ctx = AlphaContext(ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors))
 
     index = bench.index
     lo, hi = _to_ts(start, index), _to_ts(end, index)
@@ -721,9 +719,7 @@ def compute_horizon(
         "signal": lambda: signal_scorer(strat),
         "scanner": lambda: scanner_scorer(_scanner(scanner)),
     }[source]()
-    ctx = AlphaContext(
-        ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors)
-    )
+    ctx = AlphaContext(ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors))
 
     index = bench.index
     window = index[(index >= _to_ts(start, index)) & (index <= _to_ts(end, index))]

--- a/src/services/analysis.py
+++ b/src/services/analysis.py
@@ -9,7 +9,7 @@ artifact file and referenced by path - never inlined.
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -24,7 +24,13 @@ from src.alphas import (
     strategy_scorer,
 )
 from src.analytics import metrics as m
-from src.data import ClientBarSource, FeaturePanel, add_risk_features, add_score_feature
+from src.data import (
+    ClientBarSource,
+    FeaturePanel,
+    add_factor_exposure_features,
+    add_risk_features,
+    add_score_feature,
+)
 from src.engine.backtest import BacktestEngine
 from src.marketdata.client import MarketDataClient
 from src.marketdata.timeframe import Timeframe
@@ -343,6 +349,7 @@ def compute_alphas(
     ic: float = DEFAULT_IC,
     benchmark: str = "SPY",
     neutralize: bool = False,
+    neutralize_factors: Sequence[str] = (),
     lookback_days: int = 180,
     timeframe: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -378,9 +385,11 @@ def compute_alphas(
 
     panel = FeaturePanel.for_universe(as_of, list(universe_bars))
     add_risk_features(panel, universe_bars, bench_frame, periods_per_year)
+    if neutralize_factors:
+        add_factor_exposure_features(panel, universe_bars, bench_frame, neutralize_factors)
     add_score_feature(panel, scorer(), universe_bars)
 
-    context = AlphaContext(ic=ic, neutralize=neutralize)
+    context = AlphaContext(ic=ic, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors))
     refine_alpha(panel, context)
     alphas = panel_to_alphas(panel, context)
 
@@ -407,6 +416,8 @@ def compute_alphas(
         "benchmark": benchmark,
         "benchmark_available": bool(panel.meta.get("benchmark_available")),
         "neutralize": neutralize,
+        "neutralize_factors": list(neutralize_factors),
+        "neutralized_against": list(panel.meta.get("neutralized_against", [])),
         "universe_size": int(panel.get("score").notna().sum()) if panel.has("score") else 0,
         "low_confidence": bool(panel.meta.get("low_confidence")),
         "alphas": _jsonable(table),
@@ -423,6 +434,7 @@ def compute_combined_alphas(
     as_of: datetime,
     benchmark: str = "SPY",
     neutralize: bool = False,
+    neutralize_factors: Sequence[str] = (),
     lookback_days: int = 365,
     timeframe: str = "1Day",
     horizon: int = 5,
@@ -464,8 +476,14 @@ def compute_combined_alphas(
     panel = FeaturePanel.for_universe(as_of, list(universe_bars))
     panel.set("score", combined_score(universe_bars, scorers, measurement, as_of))
     add_risk_features(panel, universe_bars, bench_frame, periods_per_year)
+    if neutralize_factors:
+        add_factor_exposure_features(panel, universe_bars, bench_frame, neutralize_factors)
     # The combined, measured, shrunk IC replaces the assumed scalar (no double-scaling).
-    context = AlphaContext(ic=measurement.combined_ic, neutralize=neutralize)
+    context = AlphaContext(
+        ic=measurement.combined_ic,
+        neutralize=neutralize,
+        neutralize_factors=tuple(neutralize_factors),
+    )
     refine_alpha(panel, context)
     alphas = panel_to_alphas(panel, context)
 
@@ -488,6 +506,8 @@ def compute_combined_alphas(
         "timeframe": timeframe,
         "benchmark": benchmark,
         "neutralize": neutralize,
+        "neutralize_factors": list(neutralize_factors),
+        "neutralized_against": list(panel.meta.get("neutralized_against", [])),
         "universe_size": int(panel.get("score").notna().sum()) if panel.has("score") else 0,
         "low_confidence": bool(panel.meta.get("low_confidence")),
         "n_periods": measurement.n_periods,
@@ -513,6 +533,7 @@ def compute_information(
     scanner: str = "volume",
     benchmark: str = "SPY",
     neutralize: bool = True,
+    neutralize_factors: Sequence[str] = (),
     ic_prior: float = DEFAULT_IC,
     horizon: int = 5,
     n_points: int = 24,
@@ -558,7 +579,9 @@ def compute_information(
         "signal": lambda: signal_scorer(strat),
         "scanner": lambda: scanner_scorer(_scanner(scanner)),
     }[source]()
-    ctx = AlphaContext(ic=ic_prior, neutralize=neutralize)
+    ctx = AlphaContext(
+        ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors)
+    )
 
     index = bench.index
     lo, hi = _to_ts(start, index), _to_ts(end, index)
@@ -660,6 +683,7 @@ def compute_horizon(
     scanner: str = "volume",
     benchmark: str = "SPY",
     neutralize: bool = True,
+    neutralize_factors: Sequence[str] = (),
     ic_prior: float = DEFAULT_IC,
     max_lag: int = 10,
     n_points: int = 20,
@@ -697,7 +721,9 @@ def compute_horizon(
         "signal": lambda: signal_scorer(strat),
         "scanner": lambda: scanner_scorer(_scanner(scanner)),
     }[source]()
-    ctx = AlphaContext(ic=ic_prior, neutralize=neutralize)
+    ctx = AlphaContext(
+        ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors)
+    )
 
     index = bench.index
     window = index[(index >= _to_ts(start, index)) & (index <= _to_ts(end, index))]
@@ -869,6 +895,7 @@ def construct_portfolio(
     max_names: Optional[int] = None,
     benchmark: str = "SPY",
     neutralize: bool = True,
+    neutralize_factors: Sequence[str] = (),
     risk_model: str = "shrinkage",
     lookback_days: int = 365,
     timeframe: str = "1Day",
@@ -915,8 +942,12 @@ def construct_portfolio(
     # Alphas (the value) and Σ (the risk denominator), both as of the same moment.
     panel = FeaturePanel.for_universe(as_of, list(universe_bars))
     add_risk_features(panel, universe_bars, bench_frame, periods_per_year)
+    if neutralize_factors:
+        add_factor_exposure_features(panel, universe_bars, bench_frame, neutralize_factors)
     add_score_feature(panel, scorer(), universe_bars)
-    alpha_ctx = AlphaContext(ic=DEFAULT_IC, neutralize=neutralize)
+    alpha_ctx = AlphaContext(
+        ic=DEFAULT_IC, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors)
+    )
     refine_alpha(panel, alpha_ctx)
     alphas = panel_to_alphas(panel, alpha_ctx)
     matrix = _build_covariance(risk_model, universe_bars, bench_frame, periods_per_year)
@@ -1143,6 +1174,8 @@ def _alpha_cross_section(universe_bars, bench, scorer, periods_per_year, t, ctx)
     bench_t = bench.loc[bench.index <= t]
     panel = FeaturePanel.for_universe(t, list(ub_t))
     add_risk_features(panel, ub_t, bench_t, periods_per_year)
+    if ctx.neutralize_factors:
+        add_factor_exposure_features(panel, ub_t, bench_t, ctx.neutralize_factors)
     add_score_feature(panel, scorer, ub_t)
     refine_alpha(panel, ctx)
     return pd.Series({a.symbol: a.alpha for a in panel_to_alphas(panel, ctx)})

--- a/tests/test_alphas.py
+++ b/tests/test_alphas.py
@@ -94,6 +94,104 @@ def test_refine_neutralize_is_beta_orthogonal():
     assert abs(float(np.dot(z.values, b.values))) < 1e-9
 
 
+def test_neutralize_multi_column_orthogonal_to_each():
+    """One regression on the exposure union: residual orthogonal to every column."""
+    rng = np.random.default_rng(7)
+    names = [f"S{i}" for i in range(20)]
+    z = pd.Series(rng.normal(size=20), index=names)
+    exposures = pd.DataFrame(
+        {"exp_volatility": rng.normal(size=20), "exp_size": rng.normal(size=20)}, index=names
+    )
+    resid = refine.neutralize(z, exposures)
+    assert abs(resid.mean()) < 1e-9
+    for col in exposures:
+        assert abs(float(np.dot(resid.values, exposures[col].values))) < 1e-9
+
+
+def test_refine_factor_neutral_is_orthogonal_to_exposure_columns():
+    """neutralize_factors regresses out exp_<factor> columns; beta may stay exposed."""
+    rng = np.random.default_rng(11)
+    raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
+    panel = _panel(raw, betas={f"S{i}": 1.0 + 0.1 * i for i in range(12)})
+    panel.set("exp_volatility", {s: float(v) for s, v in zip(raw, rng.normal(size=12))})
+    panel.set("exp_size", {s: float(v) for s, v in zip(raw, rng.normal(size=12))})
+
+    refine_alpha(panel, AlphaContext(ic=0.04, neutralize_factors=("volatility", "size")))
+    z = panel.get("z")
+    for col in ("exp_volatility", "exp_size"):
+        assert abs(float(np.dot(z.values, panel.get(col).reindex(z.index).values))) < 1e-9
+
+
+def test_refine_market_factor_supersedes_plain_beta():
+    """With 'market' in neutralize_factors, the standardized exposure column is used
+    (plain beta is skipped) and the residual is orthogonal to it."""
+    raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
+    betas = {f"S{i}": 1.0 + 0.1 * i for i in range(12)}
+    panel = _panel(raw, betas=betas)
+    exp_market = refine.zscore(pd.Series(betas))
+    panel.set("exp_market", exp_market)
+
+    refine_alpha(panel, AlphaContext(ic=0.04, neutralize=True, neutralize_factors=("market",)))
+    z = panel.get("z")
+    assert abs(float(np.dot(z.values, exp_market.reindex(z.index).values))) < 1e-9
+    # Standardized market exposure is affine in beta, so beta-orthogonality follows too.
+    assert abs(float(np.dot(z.values, pd.Series(betas).reindex(z.index).values))) < 1e-9
+
+
+def test_refine_names_missing_exposures_are_mean_imputed_not_dropped():
+    """A name missing a factor value gets the cross-sectional mean (0), staying in
+    the regression — it must not silently lose beta neutralisation (G&K union trap)."""
+    raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
+    betas = {f"S{i}": 1.0 + 0.1 * i for i in range(12)}
+    panel = _panel(raw, betas=betas)
+    covered = [s for s in list(raw) if s != "S0"]
+    rng = np.random.default_rng(3)
+    panel.set("exp_size", {s: float(v) for s, v in zip(covered, rng.normal(size=len(covered)))})
+
+    refine_alpha(panel, AlphaContext(ic=0.04, neutralize=True, neutralize_factors=("size",)))
+    z = panel.get("z")
+    b = pd.Series(betas).reindex(z.index)
+    imputed_size = panel.get("exp_size").reindex(z.index).fillna(0.0)
+    # The WHOLE cross-section (S0 included) is beta- and size-orthogonal.
+    assert abs(float(np.dot(z.values, b.values))) < 1e-9
+    assert abs(float(np.dot(z.values, imputed_size.values))) < 1e-9
+    assert panel.meta["neutralize_imputed"] == 1
+    assert panel.meta["neutralized_against"] == ["size", "beta"]
+
+
+def test_refine_unusable_exposures_fall_back_to_beta():
+    """All-NaN or constant exposure columns must degrade to beta neutralisation —
+    never to NO neutralisation (the silent-loss bug: requested market neutrality
+    on a short-history universe previously disabled beta too)."""
+    raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
+    betas = {f"S{i}": 1.0 + 0.1 * i for i in range(12)}
+    panel = _panel(raw, betas=betas)
+    panel.set("exp_market", {s: np.nan for s in raw})  # e.g. from an empty exposure build
+    panel.set("exp_volatility", {s: 1.0 for s in raw})  # constant: no cross-sectional info
+
+    refine_alpha(
+        panel,
+        AlphaContext(ic=0.04, neutralize=True, neutralize_factors=("market", "volatility")),
+    )
+    z = panel.get("z")
+    assert abs(float(np.dot(z.values, pd.Series(betas).reindex(z.index).values))) < 1e-9
+    assert panel.meta["neutralized_against"] == ["beta"]
+
+
+def test_producer_writes_nothing_on_short_history():
+    """An exposure build qualifying <2 names writes no columns, so refinement can
+    fall back to beta instead of regressing on all-NaN exposures."""
+    from src.data.features import add_factor_exposure_features
+
+    names = [f"S{i}" for i in range(12)]
+    bars = {s: make_ohlcv(n=40, seed=i, freq="1D") for i, s in enumerate(names)}  # < 61 bars
+    bench = make_ohlcv(n=40, seed=99, freq="1D")
+    panel = _panel({s: float(i % 5) - 2 for i, s in enumerate(names)})
+    add_factor_exposure_features(panel, bars, bench, ["market", "volatility", "size"])
+    assert not panel.has("exp_market")
+    assert not panel.has("exp_volatility")
+
+
 # --- scorers (the score-first migration) -------------------------------------
 def test_strategy_scorer_matches_direction():
     """A migrated strategy's score sign and discrete signal agree at a BUY bar."""
@@ -147,6 +245,31 @@ def test_alphas_are_independent_of_post_as_of_bars():
     )
     assert res_truncated["alphas"] == res_full["alphas"]
     assert res_truncated["low_confidence"] == res_full["low_confidence"]
+
+
+def test_compute_alphas_factor_neutral_end_to_end():
+    """The service threads neutralize_factors: exposures built, echoed, and applied."""
+    symbols = [f"S{i:02d}" for i in range(12)]
+    data = {s: make_ohlcv(n=250, seed=i, freq="1D") for i, s in enumerate([*symbols, "SPY"])}
+    client = MarketDataClient(DictMarketData(data))
+    as_of = data["S00"].index[-1].to_pydatetime()
+
+    plain = analysis.compute_alphas(client, "ma_crossover", symbols, as_of, benchmark="SPY")
+    neutral = analysis.compute_alphas(
+        client,
+        "ma_crossover",
+        symbols,
+        as_of,
+        benchmark="SPY",
+        neutralize_factors=("volatility", "size"),
+    )
+    assert neutral["neutralize_factors"] == ["volatility", "size"]
+    assert neutral["neutralized_against"] == ["volatility", "size"]
+    assert neutral["alphas"] and plain["alphas"]
+    # The factor regression must actually change the cross-section.
+    z_plain = {r["symbol"]: r["z"] for r in plain["alphas"]}
+    z_neutral = {r["symbol"]: r["z"] for r in neutral["alphas"]}
+    assert any(abs(z_plain[s] - z_neutral[s]) > 1e-12 for s in z_plain)
 
 
 # --- thin universe -----------------------------------------------------------

--- a/tests/test_cost_aware.py
+++ b/tests/test_cost_aware.py
@@ -300,7 +300,12 @@ def test_construct_portfolio_cost_aware_reports_the_cost_split():
     d = res["diagnostics"]
     assert d.get("cost_aware") is True
     assert "linear_cost" in d and "impact_cost" in d
-    assert d["expected_active_return_net"] == pytest.approx(d["expected_active_return"] - d["cost_drag"])
+    # Headline net is the round-trip haircut; the one-way rebalance figure stays in detail.
+    assert d["expected_active_return_net"] == pytest.approx(d["expected_active_return"] - d["round_trip_cost"])
+    assert d["expected_active_return_net_oneway"] == pytest.approx(
+        d["expected_active_return"] - d["cost_drag"]
+    )
+    assert d["cost_drag"] == pytest.approx(d["linear_cost"] + d["impact_cost"])  # one-way total
 
 
 def test_construct_portfolio_gross_objective_uses_ex_post_drag():
@@ -327,6 +332,27 @@ def test_reported_linear_cost_equals_independent_sum():
     w = _vec(res)
     c_lin, _ = MeanVarianceOptimizer._cost_coefficients(model, ci, None, H, SYMS)
     assert res.diagnostics["linear_cost"] == pytest.approx(float(np.sum(c_lin * np.abs(w))))
+
+
+# --- round-trip headline haircut --------------------------------------------
+def test_round_trip_headline_is_conservative_and_capacity_aligned():
+    model = ParametricCostModel()
+    ci = _inputs({"A": 0.02, "B": 0.001, "C": 0.0005, "D": 0.0005}, adv_dollar=1e8)
+    res = MeanVarianceOptimizer(max_weight=0.5).optimize(  # from cash → Δw = w
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci,
+        capital=1e7, holding_period_years=H,
+    )
+    d = res.diagnostics
+    w = _vec(res)
+    c_lin, k_imp = MeanVarianceOptimizer._cost_coefficients(model, ci, 1e7, H, SYMS)
+    # Round-trip = 2 × (Σ cᵢwᵢ + Σ kᵢwᵢ^{3/2}) — the same book cost capacity prices, ×2.
+    expected_rt = 2.0 * (float(np.sum(c_lin * w)) + float(np.sum(k_imp * w**1.5)))
+    assert d["round_trip_cost"] == pytest.approx(expected_rt)
+    # From cash the round-trip is exactly twice the one-way rebalance cost, and strictly
+    # more conservative than the one-way net.
+    assert d["round_trip_cost"] == pytest.approx(2.0 * d["cost_drag"])
+    assert d["expected_active_return_net"] < d["expected_active_return_net_oneway"]
+    assert d["expected_active_return_net"] == pytest.approx(d["expected_active_return"] - expected_rt)
 
 
 # --- cardinality / dust re-solve with cost (spec §4 factor 6 interaction) ----

--- a/tests/test_cost_aware.py
+++ b/tests/test_cost_aware.py
@@ -58,7 +58,12 @@ def test_zero_cost_reduces_to_cost_blind_solve():
     free = ParametricCostModel(commission_bps=0.0, default_spread_bps=0.0)
     blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
     zero = MeanVarianceOptimizer(max_weight=0.5).optimize(
-        _alphas(), _risk(), risk_aversion=LAM, cost_model=free, cost_inputs=_inputs(0.0), holding_period_years=H
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=free,
+        cost_inputs=_inputs(0.0),
+        holding_period_years=H,
     )
     assert np.allclose(_vec(zero), _vec(blind), atol=1e-9)
     # Unconstrained optimum still the spec-008 closed form, untouched by the (zero) cost.
@@ -74,7 +79,12 @@ def test_uniform_cost_from_cash_is_a_noop():
     model = ParametricCostModel()
     blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
     uniform = MeanVarianceOptimizer(max_weight=0.5).optimize(
-        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=_inputs(0.001), holding_period_years=H
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=_inputs(0.001),
+        holding_period_years=H,
     )
     assert np.allclose(_vec(uniform), _vec(blind), atol=1e-6)
 
@@ -85,8 +95,12 @@ def test_name_specific_cost_tilts_away_from_expensive_names():
     # Make the top-alpha name (A) expensive; the cost-aware optimum must down-weight it.
     expensive = {"A": 0.02, "B": 0.0005, "C": 0.0005, "D": 0.0005}
     tilted = MeanVarianceOptimizer(max_weight=0.5).optimize(
-        _alphas(), _risk(), risk_aversion=LAM, cost_model=model,
-        cost_inputs=_inputs(expensive), holding_period_years=H,
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=_inputs(expensive),
+        holding_period_years=H,
     )
     assert _vec(tilted)[0] < _vec(blind)[0] - 1e-6  # A shrinks
     assert abs(sum(tilted.weights.values()) - 1.0) < 1e-6  # still fully invested
@@ -99,11 +113,18 @@ def test_emergent_no_trade_band_suppresses_subthreshold_churn():
     base = opt.optimize(_alphas(), _risk(), risk_aversion=LAM)
     # Nudge one name's alpha by +0.02 — below its cost band (a ~100bps spread over a 1/12
     # yr hold gives a ~6%/yr band half-width), but enough that a cost-blind solve chases it.
-    nudged = [Alpha(s, float(ALPHA[i]) + (0.02 if s == "D" else 0.0), AS_OF, 0.2, 0.05, 0.0)
-              for i, s in enumerate(SYMS)]
+    nudged = [
+        Alpha(s, float(ALPHA[i]) + (0.02 if s == "D" else 0.0), AS_OF, 0.2, 0.05, 0.0)
+        for i, s in enumerate(SYMS)
+    ]
     rebal = opt.optimize(
-        nudged, _risk(), risk_aversion=LAM, current_weights=base.weights,
-        cost_model=model, cost_inputs=_inputs(0.01), holding_period_years=H,
+        nudged,
+        _risk(),
+        risk_aversion=LAM,
+        current_weights=base.weights,
+        cost_model=model,
+        cost_inputs=_inputs(0.01),
+        holding_period_years=H,
     )
     assert rebal.diagnostics["turnover"] < 1e-9  # machine epsilon: no meaningful trade
     assert rebal.diagnostics["names_traded"] == 0
@@ -147,9 +168,7 @@ def test_impact_penalty_is_superlinear_in_trade_size():
     # trade more than doubles it (×2^1.5). Uses the real _cost_coefficients so an
     # annualisation/formula bug in kᵢ would surface here, not just literal arithmetic.
     model = ParametricCostModel()
-    _, k_imp = MeanVarianceOptimizer._cost_coefficients(
-        model, _inputs(0.0005, adv_dollar=1e8), 1e7, H, SYMS
-    )
+    _, k_imp = MeanVarianceOptimizer._cost_coefficients(model, _inputs(0.0005, adv_dollar=1e8), 1e7, H, SYMS)
     assert np.all(k_imp > 0)
     p1 = k_imp[0] * 0.1**1.5
     p2 = k_imp[0] * 0.2**1.5
@@ -166,7 +185,13 @@ def test_sqrt_impact_spreads_size_away_from_illiquid_names():
         _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
     )
     conic = opt.optimize(  # capital set → √-impact active
-        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=5e7, holding_period_years=H
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=5e7,
+        holding_period_years=H,
     )
     assert conic.diagnostics["impact_cost"] > 0
     assert _vec(conic)[0] < _vec(linear)[0] - 1e-4  # A down-weighted by impact
@@ -178,9 +203,17 @@ def test_linear_and_conic_agree_when_impact_is_negligible_and_gap_is_reported():
     model = ParametricCostModel()
     ci = _inputs(0.0005, adv_dollar=1e13)  # very deep books
     opt = MeanVarianceOptimizer(max_weight=0.5)
-    linear = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H)
+    linear = opt.optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
     conic = opt.optimize(
-        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=1e5, holding_period_years=H
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=1e5,
+        holding_period_years=H,
     )
     # Deep liquidity + small capital → the √-impact term is tiny, so the two solutions
     # coincide within tolerance; the impact charge is surfaced, not hidden.
@@ -193,8 +226,24 @@ def test_conic_gap_grows_with_capital():
     model = ParametricCostModel()
     ci = _inputs(0.0005, adv_dollar=1e8)
     opt = MeanVarianceOptimizer(max_weight=0.5)
-    small = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=1e5, holding_period_years=H)
-    large = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=1e9, holding_period_years=H)
+    small = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=1e5,
+        holding_period_years=H,
+    )
+    large = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=1e9,
+        holding_period_years=H,
+    )
     assert large.diagnostics["impact_cost"] > small.diagnostics["impact_cost"]
 
 
@@ -203,14 +252,18 @@ def test_no_feasible_perturbation_beats_the_cost_aware_optimum():
     model = ParametricCostModel()
     ci = _inputs({"A": 0.02, "B": 0.0005, "C": 0.0005, "D": 0.0005})
     opt = MeanVarianceOptimizer(max_weight=0.5)
-    res = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H)
+    res = opt.optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
     w = _vec(res)
     c_lin, k_imp = MeanVarianceOptimizer._cost_coefficients(model, ci, None, H, SYMS)
     w0 = np.zeros(4)
 
     def util(x):
         dw = x - w0
-        return ALPHA @ x - LAM * (x @ SIGMA @ x) - np.sum(c_lin * np.abs(dw)) - np.sum(k_imp * np.abs(dw) ** 1.5)
+        return (
+            ALPHA @ x - LAM * (x @ SIGMA @ x) - np.sum(c_lin * np.abs(dw)) - np.sum(k_imp * np.abs(dw) ** 1.5)
+        )
 
     u_opt = util(w)
     rng = np.random.default_rng(0)
@@ -294,14 +347,18 @@ def test_construct_portfolio_cost_aware_reports_the_cost_split():
     from src.services import analysis
 
     symbols, dc = _universe()
-    res = analysis.construct_portfolio(dc, "ma_crossover", symbols, AS_OF, capital=1_000_000.0, cost_aware=True)
+    res = analysis.construct_portfolio(
+        dc, "ma_crossover", symbols, AS_OF, capital=1_000_000.0, cost_aware=True
+    )
     if not res["feasible"]:
         pytest.skip("fixture produced no feasible portfolio")
     d = res["diagnostics"]
     assert d.get("cost_aware") is True
     assert "linear_cost" in d and "impact_cost" in d
     # Headline net is the round-trip haircut; the one-way rebalance figure stays in detail.
-    assert d["expected_active_return_net"] == pytest.approx(d["expected_active_return"] - d["round_trip_cost"])
+    assert d["expected_active_return_net"] == pytest.approx(
+        d["expected_active_return"] - d["round_trip_cost"]
+    )
     assert d["expected_active_return_net_oneway"] == pytest.approx(
         d["expected_active_return"] - d["cost_drag"]
     )
@@ -312,7 +369,9 @@ def test_construct_portfolio_gross_objective_uses_ex_post_drag():
     from src.services import analysis
 
     symbols, dc = _universe()
-    res = analysis.construct_portfolio(dc, "ma_crossover", symbols, AS_OF, capital=1_000_000.0, cost_aware=False)
+    res = analysis.construct_portfolio(
+        dc, "ma_crossover", symbols, AS_OF, capital=1_000_000.0, cost_aware=False
+    )
     if not res["feasible"]:
         pytest.skip("fixture produced no feasible portfolio")
     d = res["diagnostics"]
@@ -339,8 +398,13 @@ def test_round_trip_headline_is_conservative_and_capacity_aligned():
     model = ParametricCostModel()
     ci = _inputs({"A": 0.02, "B": 0.001, "C": 0.0005, "D": 0.0005}, adv_dollar=1e8)
     res = MeanVarianceOptimizer(max_weight=0.5).optimize(  # from cash → Δw = w
-        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci,
-        capital=1e7, holding_period_years=H,
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=1e7,
+        holding_period_years=H,
     )
     d = res.diagnostics
     w = _vec(res)
@@ -362,8 +426,13 @@ def test_cardinality_liquidation_cost_is_counted():
     model = ParametricCostModel()
     w0 = {s: 0.25 for s in SYMS}
     res = MeanVarianceOptimizer(max_weight=0.5, max_names=2).optimize(
-        _alphas(), _risk(), risk_aversion=LAM, current_weights=w0,
-        cost_model=model, cost_inputs=_inputs(0.001), holding_period_years=H,
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        current_weights=w0,
+        cost_model=model,
+        cost_inputs=_inputs(0.001),
+        holding_period_years=H,
     )
     assert len(res.weights) <= 2
     c_lin, _ = MeanVarianceOptimizer._cost_coefficients(model, _inputs(0.001), None, H, SYMS)
@@ -377,7 +446,12 @@ def test_cardinality_liquidation_cost_is_counted():
 def test_dust_floor_liquidation_is_priced_with_cost():
     model = ParametricCostModel()
     res = MeanVarianceOptimizer(max_weight=0.5, min_weight=0.1).optimize(
-        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=_inputs(0.001), holding_period_years=H
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=_inputs(0.001),
+        holding_period_years=H,
     )
     assert all(v >= 0.1 - 1e-9 for v in res.weights.values())  # no dust survives
     assert abs(sum(res.weights.values()) - 1.0) < 1e-6
@@ -395,7 +469,13 @@ def test_missing_adv_name_gets_linear_only_others_get_impact():
     c_lin, k_imp = MeanVarianceOptimizer._cost_coefficients(model, ci, 5e7, H, SYMS)
     assert k_imp[0] == 0.0 and np.all(k_imp[1:] > 0)  # A linear-only, others conic
     res = MeanVarianceOptimizer(max_weight=0.5).optimize(
-        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=5e7, holding_period_years=H
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=5e7,
+        holding_period_years=H,
     )
     assert res.feasible and abs(sum(res.weights.values()) - 1.0) < 1e-6
 
@@ -404,8 +484,24 @@ def test_zero_capital_equals_linear_only_solve():
     model = ParametricCostModel()
     ci = _inputs(0.0005, adv_dollar=1e8)
     opt = MeanVarianceOptimizer(max_weight=0.5)
-    zero_cap = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=0.0, holding_period_years=H)
-    no_cap = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=None, holding_period_years=H)
+    zero_cap = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=0.0,
+        holding_period_years=H,
+    )
+    no_cap = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=model,
+        cost_inputs=ci,
+        capital=None,
+        holding_period_years=H,
+    )
     assert zero_cap.diagnostics["impact_cost"] == 0.0
     assert np.allclose(_vec(zero_cap), _vec(no_cap))
 
@@ -414,8 +510,24 @@ def test_linear_impact_mode_disables_the_conic_term_in_the_solve():
     linear_model = ParametricCostModel(linear_impact=True)
     ci = _inputs(0.0005, adv_dollar=1e7)  # illiquid → would accrue √-impact if enabled
     opt = MeanVarianceOptimizer(max_weight=0.5)
-    lin = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=linear_model, cost_inputs=ci, capital=5e7, holding_period_years=H)
-    only_linear = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=linear_model, cost_inputs=ci, capital=None, holding_period_years=H)
+    lin = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=linear_model,
+        cost_inputs=ci,
+        capital=5e7,
+        holding_period_years=H,
+    )
+    only_linear = opt.optimize(
+        _alphas(),
+        _risk(),
+        risk_aversion=LAM,
+        cost_model=linear_model,
+        cost_inputs=ci,
+        capital=None,
+        holding_period_years=H,
+    )
     assert lin.diagnostics["impact_cost"] == 0.0  # conic term not fed to the optimiser
     assert np.allclose(_vec(lin), _vec(only_linear))
 

--- a/tests/test_cost_aware.py
+++ b/tests/test_cost_aware.py
@@ -1,0 +1,407 @@
+"""Tests for cost-aware portfolio construction (spec 016).
+
+Cost is inside the objective: ``αᵀw − λ·wᵀΣw − Σ cᵢ|Δwᵢ| − Σ kᵢ|Δwᵢ|^{3/2}``. These
+tests cover the spec §6 checklist — name-specific tilt, the emergent no-trade band,
+w₀ sensitivity, √-impact super-linearity, the linear↔conic gap, and the zero-cost
+reduction to spec 008 — plus the proximal-operator primitives, a KKT optimality
+certificate, the cost-model coefficients, and the end-to-end service integration.
+
+Offline and deterministic.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pytest
+
+from src.alphas.base import Alpha
+from src.costs import ParametricCostModel
+from src.costs.base import CostModel, Trade
+from src.marketdata.client import MarketDataClient
+from src.portfolio.optimizer import CostInputs, MeanVarianceOptimizer
+from src.risk.base import RiskMatrix
+from tests.fakes import DictMarketData, make_ohlcv
+
+AS_OF = datetime(2024, 6, 1)
+SYMS = ["A", "B", "C", "D"]
+_L = np.array([[0.20, 0, 0, 0], [0.05, 0.18, 0, 0], [0.03, 0.04, 0.22, 0], [0.01, 0.02, 0.03, 0.16]])
+SIGMA = _L @ _L.T
+ALPHA = np.array([0.06, 0.02, -0.01, 0.04])
+LAM = 2.0
+H = 1.0 / 12.0
+
+
+def _alphas(bump: float = 0.0) -> list:
+    return [Alpha(s, float(ALPHA[i]) + bump, AS_OF, 0.2, 0.05, 0.0) for i, s in enumerate(SYMS)]
+
+
+def _risk() -> RiskMatrix:
+    return RiskMatrix(SYMS, SIGMA)
+
+
+def _vec(result) -> np.ndarray:
+    return np.array([result.weights.get(s, 0.0) for s in SYMS])
+
+
+def _inputs(spread, adv_dollar=1e12, daily_vol=0.02) -> CostInputs:
+    """A CostInputs with a uniform (or per-name dict) spread and deep default liquidity."""
+    sp = spread if isinstance(spread, dict) else {s: spread for s in SYMS}
+    return CostInputs(
+        spread=sp,
+        adv_dollar={s: adv_dollar for s in SYMS},
+        daily_vol={s: daily_vol for s in SYMS},
+    )
+
+
+# --- closed-form / zero-cost reduction (spec §6 "closed-form sanity") --------
+def test_zero_cost_reduces_to_cost_blind_solve():
+    free = ParametricCostModel(commission_bps=0.0, default_spread_bps=0.0)
+    blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
+    zero = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=free, cost_inputs=_inputs(0.0), holding_period_years=H
+    )
+    assert np.allclose(_vec(zero), _vec(blind), atol=1e-9)
+    # Unconstrained optimum still the spec-008 closed form, untouched by the (zero) cost.
+    expected = (np.linalg.inv(SIGMA) @ ALPHA) / (2 * LAM)
+    got = np.array([blind.unconstrained_weights[s] for s in SYMS])
+    assert np.allclose(got, expected)
+
+
+# --- name-specific cost changes weights (spec §6 test 1) ---------------------
+def test_uniform_cost_from_cash_is_a_noop():
+    # Long-only from cash with a uniform per-name cost: Σcᵢ|wᵢ| = c·Σwᵢ = c is constant,
+    # so the optimum is unchanged — the baseline the name-specific case must beat.
+    model = ParametricCostModel()
+    blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
+    uniform = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=_inputs(0.001), holding_period_years=H
+    )
+    assert np.allclose(_vec(uniform), _vec(blind), atol=1e-6)
+
+
+def test_name_specific_cost_tilts_away_from_expensive_names():
+    model = ParametricCostModel()
+    blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
+    # Make the top-alpha name (A) expensive; the cost-aware optimum must down-weight it.
+    expensive = {"A": 0.02, "B": 0.0005, "C": 0.0005, "D": 0.0005}
+    tilted = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model,
+        cost_inputs=_inputs(expensive), holding_period_years=H,
+    )
+    assert _vec(tilted)[0] < _vec(blind)[0] - 1e-6  # A shrinks
+    assert abs(sum(tilted.weights.values()) - 1.0) < 1e-6  # still fully invested
+
+
+# --- emergent no-trade band (spec §6 test 2) ---------------------------------
+def test_emergent_no_trade_band_suppresses_subthreshold_churn():
+    model = ParametricCostModel()
+    opt = MeanVarianceOptimizer(max_weight=0.5)  # no_trade_band=0: the band must EMERGE from cost
+    base = opt.optimize(_alphas(), _risk(), risk_aversion=LAM)
+    # Nudge one name's alpha by +0.02 — below its cost band (a ~100bps spread over a 1/12
+    # yr hold gives a ~6%/yr band half-width), but enough that a cost-blind solve chases it.
+    nudged = [Alpha(s, float(ALPHA[i]) + (0.02 if s == "D" else 0.0), AS_OF, 0.2, 0.05, 0.0)
+              for i, s in enumerate(SYMS)]
+    rebal = opt.optimize(
+        nudged, _risk(), risk_aversion=LAM, current_weights=base.weights,
+        cost_model=model, cost_inputs=_inputs(0.01), holding_period_years=H,
+    )
+    assert rebal.diagnostics["turnover"] < 1e-9  # machine epsilon: no meaningful trade
+    assert rebal.diagnostics["names_traded"] == 0
+    # Without the cost, the same nudge chases the alpha — the band is doing the work.
+    chase = opt.optimize(nudged, _risk(), risk_aversion=LAM, current_weights=base.weights)
+    assert chase.diagnostics["turnover"] > 1e-3
+
+
+def test_no_trade_band_half_width_is_the_one_way_cost():
+    # The band edge is the soft-threshold in _prox_step: no trade iff |m| ≤ thr, where
+    # thr = one-way cost cᵢ. Full band width (buy edge − sell edge) = 2cᵢ = round trip.
+    m = np.array([-0.05, -0.011, -0.009, 0.009, 0.011, 0.05])
+    thr = np.full_like(m, 0.01)
+    d = MeanVarianceOptimizer._prox_step(m, thr, np.zeros_like(m))
+    assert list(np.abs(d) > 0) == [True, True, False, False, True, True]  # zero strictly inside ±thr
+
+    model = ParametricCostModel(commission_bps=1.0, default_spread_bps=5.0)
+    c_one_way = model.turnover_cost_rate() / H  # cᵢ, annualised one-way
+    c_lin, _ = MeanVarianceOptimizer._cost_coefficients(model, _inputs(model.default_spread), None, H, SYMS)
+    assert np.allclose(c_lin, c_one_way)
+    # Full band width = 2·cᵢ equals the annualised round-trip rate (impact→0 for a tiny trade).
+    tiny = Trade("A", shares=1e-6, price=100.0, adv=1e12, daily_vol=0.02, spread=model.default_spread)
+    assert 2 * c_one_way == pytest.approx(model.annual_cost_rate(tiny, H), rel=1e-6)
+
+
+# --- w0 sensitivity (spec §6 test 3) -----------------------------------------
+def test_turnover_depends_on_current_weights():
+    model = ParametricCostModel()
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    kw = dict(cost_model=model, cost_inputs=_inputs(0.0005), holding_period_years=H)
+    target = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, **kw)
+    from_target = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, current_weights=target.weights, **kw)
+    from_cash = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, current_weights={}, **kw)
+    assert from_target.diagnostics["turnover"] < 1e-6  # already optimal → no trade
+    assert from_cash.diagnostics["turnover"] > 0.5  # from cash → fully invest
+
+
+# --- √-impact super-linearity (spec §6 test 4) -------------------------------
+def test_impact_penalty_is_superlinear_in_trade_size():
+    # The penalty kᵢ·|Δw|^{3/2} under the optimiser's *own* coefficient: doubling the
+    # trade more than doubles it (×2^1.5). Uses the real _cost_coefficients so an
+    # annualisation/formula bug in kᵢ would surface here, not just literal arithmetic.
+    model = ParametricCostModel()
+    _, k_imp = MeanVarianceOptimizer._cost_coefficients(
+        model, _inputs(0.0005, adv_dollar=1e8), 1e7, H, SYMS
+    )
+    assert np.all(k_imp > 0)
+    p1 = k_imp[0] * 0.1**1.5
+    p2 = k_imp[0] * 0.2**1.5
+    assert p2 / p1 == pytest.approx(2**1.5)
+
+
+def test_sqrt_impact_spreads_size_away_from_illiquid_names():
+    model = ParametricCostModel()
+    # A (top alpha) is illiquid; the rest are deep. Impact should pull size off A.
+    adv = {"A": 5e6, "B": 5e11, "C": 5e11, "D": 5e11}
+    ci = CostInputs(spread={s: 0.0005 for s in SYMS}, adv_dollar=adv, daily_vol={s: 0.03 for s in SYMS})
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    linear = opt.optimize(  # capital=None → linear only, no √-impact
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
+    conic = opt.optimize(  # capital set → √-impact active
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=5e7, holding_period_years=H
+    )
+    assert conic.diagnostics["impact_cost"] > 0
+    assert _vec(conic)[0] < _vec(linear)[0] - 1e-4  # A down-weighted by impact
+    assert abs(sum(conic.weights.values()) - 1.0) < 1e-6
+
+
+# --- linear ↔ conic gap (spec §6 test 5) -------------------------------------
+def test_linear_and_conic_agree_when_impact_is_negligible_and_gap_is_reported():
+    model = ParametricCostModel()
+    ci = _inputs(0.0005, adv_dollar=1e13)  # very deep books
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    linear = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H)
+    conic = opt.optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=1e5, holding_period_years=H
+    )
+    # Deep liquidity + small capital → the √-impact term is tiny, so the two solutions
+    # coincide within tolerance; the impact charge is surfaced, not hidden.
+    assert np.max(np.abs(_vec(linear) - _vec(conic))) < 1e-3
+    assert "impact_cost" in conic.diagnostics
+    assert conic.diagnostics["impact_cost"] < 1e-4
+
+
+def test_conic_gap_grows_with_capital():
+    model = ParametricCostModel()
+    ci = _inputs(0.0005, adv_dollar=1e8)
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    small = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=1e5, holding_period_years=H)
+    large = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=1e9, holding_period_years=H)
+    assert large.diagnostics["impact_cost"] > small.diagnostics["impact_cost"]
+
+
+# --- KKT optimality certificate ----------------------------------------------
+def test_no_feasible_perturbation_beats_the_cost_aware_optimum():
+    model = ParametricCostModel()
+    ci = _inputs({"A": 0.02, "B": 0.0005, "C": 0.0005, "D": 0.0005})
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    res = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H)
+    w = _vec(res)
+    c_lin, k_imp = MeanVarianceOptimizer._cost_coefficients(model, ci, None, H, SYMS)
+    w0 = np.zeros(4)
+
+    def util(x):
+        dw = x - w0
+        return ALPHA @ x - LAM * (x @ SIGMA @ x) - np.sum(c_lin * np.abs(dw)) - np.sum(k_imp * np.abs(dw) ** 1.5)
+
+    u_opt = util(w)
+    rng = np.random.default_rng(0)
+    beats = 0
+    for _ in range(5000):
+        i, j = rng.integers(0, 4, 2)
+        eps = rng.uniform(0, 0.02)
+        wp = w.copy()
+        wp[i] += eps
+        wp[j] -= eps  # budget-preserving swap
+        if wp[i] <= 0.5 + 1e-12 and wp[j] >= -1e-12 and util(wp) > u_opt + 1e-8:
+            beats += 1
+    assert beats == 0
+
+
+# --- proximal-operator primitive ---------------------------------------------
+def test_prox_step_matches_brute_force_minimizer():
+    grid = np.linspace(-0.6, 0.6, 24001)
+    for m, thr, kthr in [(0.3, 0.05, 0.0), (0.3, 0.05, 0.4), (-0.25, 0.02, 0.7), (0.01, 0.05, 0.4)]:
+        obj = 0.5 * (grid - m) ** 2 + thr * np.abs(grid) + kthr * np.abs(grid) ** 1.5
+        brute = grid[int(np.argmin(obj))]
+        closed = float(MeanVarianceOptimizer._prox_step(np.array([m]), np.array([thr]), np.array([kthr]))[0])
+        assert abs(closed - brute) < 1e-3
+
+
+def test_prox_step_reduces_to_soft_threshold_without_impact():
+    m = np.array([-0.3, -0.02, 0.0, 0.02, 0.3])
+    thr = np.full_like(m, 0.05)
+    got = MeanVarianceOptimizer._prox_step(m, thr, np.zeros_like(m))
+    expected = np.sign(m) * np.maximum(np.abs(m) - thr, 0.0)
+    assert np.allclose(got, expected)
+
+
+# --- cost-model coefficients -------------------------------------------------
+def test_impact_coefficient_formula_and_missing_data():
+    model = ParametricCostModel(impact_eta=0.3)
+    assert model.impact_coefficient(0.02, adv_dollar=1e8, capital=1e6) == pytest.approx(
+        0.3 * 0.02 * np.sqrt(1e6 / 1e8)
+    )
+    assert model.impact_coefficient(0.02, adv_dollar=0.0, capital=1e6) == 0.0  # no ADV → no impact
+    assert model.impact_coefficient(0.02, adv_dollar=1e8, capital=0.0) == 0.0  # no capital → no impact
+    assert ParametricCostModel(linear_impact=True).impact_coefficient(0.02, 1e8, 1e6) == 0.0
+
+
+def test_base_cost_model_has_zero_cost_defaults():
+    class Null(CostModel):
+        def cost(self, trade):  # pragma: no cover - trivial
+            from src.costs.base import TradeCost
+
+            return TradeCost(0, 0, 0, 0, capped=False)
+
+    null = Null()
+    assert null.turnover_cost_rate() == 0.0
+    assert null.impact_coefficient(0.02, 1e8, 1e6) == 0.0
+
+
+# --- spread proxy ------------------------------------------------------------
+def test_spread_proxy_is_monotone_in_range_and_clamped():
+    from src.services.analysis import _spread_proxy
+
+    model = ParametricCostModel()
+    tight = make_ohlcv(n=60, seed=1, freq="1D")
+    wide = tight.assign(high=tight["high"] * 1.5, low=tight["low"] * 0.5)  # a much wider range
+    assert _spread_proxy(wide, model) >= _spread_proxy(tight, model)
+    assert _spread_proxy(wide, model) <= 0.02  # capped
+    assert _spread_proxy(tight, model) >= model.default_spread * 0.2  # floored
+    # No OHLC → the model default.
+    import pandas as pd
+
+    assert _spread_proxy(pd.DataFrame({"close": [1.0, 2.0]}), model) == model.default_spread
+
+
+# --- service integration -----------------------------------------------------
+def _universe():
+    symbols = [f"S{i}" for i in range(8)]
+    bars = {s: make_ohlcv(n=300, seed=i, freq="1D") for i, s in enumerate([*symbols, "SPY"])}
+    return symbols, MarketDataClient(DictMarketData(bars))
+
+
+def test_construct_portfolio_cost_aware_reports_the_cost_split():
+    from src.services import analysis
+
+    symbols, dc = _universe()
+    res = analysis.construct_portfolio(dc, "ma_crossover", symbols, AS_OF, capital=1_000_000.0, cost_aware=True)
+    if not res["feasible"]:
+        pytest.skip("fixture produced no feasible portfolio")
+    d = res["diagnostics"]
+    assert d.get("cost_aware") is True
+    assert "linear_cost" in d and "impact_cost" in d
+    assert d["expected_active_return_net"] == pytest.approx(d["expected_active_return"] - d["cost_drag"])
+
+
+def test_construct_portfolio_gross_objective_uses_ex_post_drag():
+    from src.services import analysis
+
+    symbols, dc = _universe()
+    res = analysis.construct_portfolio(dc, "ma_crossover", symbols, AS_OF, capital=1_000_000.0, cost_aware=False)
+    if not res["feasible"]:
+        pytest.skip("fixture produced no feasible portfolio")
+    d = res["diagnostics"]
+    assert not d.get("cost_aware")
+    assert "cost_drag" in d  # ex-post drag still reported on the cost-blind solve
+
+
+# --- reported-value integrity ------------------------------------------------
+def test_reported_linear_cost_equals_independent_sum():
+    # Pin the diagnostic against an independently computed Σ cᵢ|Δwᵢ| (from cash, w₀=0),
+    # so a coefficient or annualisation bug surfaces (not just the net = gross − cost id).
+    model = ParametricCostModel()
+    ci = _inputs({"A": 0.02, "B": 0.001, "C": 0.0005, "D": 0.0005})
+    res = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
+    w = _vec(res)
+    c_lin, _ = MeanVarianceOptimizer._cost_coefficients(model, ci, None, H, SYMS)
+    assert res.diagnostics["linear_cost"] == pytest.approx(float(np.sum(c_lin * np.abs(w))))
+
+
+# --- cardinality / dust re-solve with cost (spec §4 factor 6 interaction) ----
+def test_cardinality_liquidation_cost_is_counted():
+    # A full-book w₀ with max_names=2 must fully liquidate the dropped names; that
+    # liquidation turnover and its cost must appear in the diagnostics (priced over w−w₀).
+    model = ParametricCostModel()
+    w0 = {s: 0.25 for s in SYMS}
+    res = MeanVarianceOptimizer(max_weight=0.5, max_names=2).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, current_weights=w0,
+        cost_model=model, cost_inputs=_inputs(0.001), holding_period_years=H,
+    )
+    assert len(res.weights) <= 2
+    c_lin, _ = MeanVarianceOptimizer._cost_coefficients(model, _inputs(0.001), None, H, SYMS)
+    w = _vec(res)
+    w0v = np.array([w0[s] for s in SYMS])
+    assert res.diagnostics["turnover"] == pytest.approx(float(np.sum(np.abs(w - w0v))))
+    assert res.diagnostics["linear_cost"] == pytest.approx(float(np.sum(c_lin * np.abs(w - w0v))))
+    assert res.diagnostics["linear_cost"] > 0  # the two liquidations are charged
+
+
+def test_dust_floor_liquidation_is_priced_with_cost():
+    model = ParametricCostModel()
+    res = MeanVarianceOptimizer(max_weight=0.5, min_weight=0.1).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=_inputs(0.001), holding_period_years=H
+    )
+    assert all(v >= 0.1 - 1e-9 for v in res.weights.values())  # no dust survives
+    assert abs(sum(res.weights.values()) - 1.0) < 1e-6
+
+
+# --- missing ADV / zero capital / linear-impact through the solve ------------
+def test_missing_adv_name_gets_linear_only_others_get_impact():
+    model = ParametricCostModel()
+    # Only A lacks ADV; the rest are illiquid enough to accrue impact.
+    ci = CostInputs(
+        spread={s: 0.0005 for s in SYMS},
+        adv_dollar={"B": 5e7, "C": 5e7, "D": 5e7},  # A omitted → kA = 0
+        daily_vol={s: 0.03 for s in SYMS},
+    )
+    c_lin, k_imp = MeanVarianceOptimizer._cost_coefficients(model, ci, 5e7, H, SYMS)
+    assert k_imp[0] == 0.0 and np.all(k_imp[1:] > 0)  # A linear-only, others conic
+    res = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=5e7, holding_period_years=H
+    )
+    assert res.feasible and abs(sum(res.weights.values()) - 1.0) < 1e-6
+
+
+def test_zero_capital_equals_linear_only_solve():
+    model = ParametricCostModel()
+    ci = _inputs(0.0005, adv_dollar=1e8)
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    zero_cap = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=0.0, holding_period_years=H)
+    no_cap = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, capital=None, holding_period_years=H)
+    assert zero_cap.diagnostics["impact_cost"] == 0.0
+    assert np.allclose(_vec(zero_cap), _vec(no_cap))
+
+
+def test_linear_impact_mode_disables_the_conic_term_in_the_solve():
+    linear_model = ParametricCostModel(linear_impact=True)
+    ci = _inputs(0.0005, adv_dollar=1e7)  # illiquid → would accrue √-impact if enabled
+    opt = MeanVarianceOptimizer(max_weight=0.5)
+    lin = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=linear_model, cost_inputs=ci, capital=5e7, holding_period_years=H)
+    only_linear = opt.optimize(_alphas(), _risk(), risk_aversion=LAM, cost_model=linear_model, cost_inputs=ci, capital=None, holding_period_years=H)
+    assert lin.diagnostics["impact_cost"] == 0.0  # conic term not fed to the optimiser
+    assert np.allclose(_vec(lin), _vec(only_linear))
+
+
+# --- robustness: a bad cost input must not poison the solve ------------------
+def test_nan_spread_does_not_poison_the_solve():
+    model = ParametricCostModel()
+    ci = CostInputs(spread={"A": float("nan"), "B": 0.0005, "C": 0.0005, "D": 0.0005})
+    res = MeanVarianceOptimizer(max_weight=0.5).optimize(
+        _alphas(), _risk(), risk_aversion=LAM, cost_model=model, cost_inputs=ci, holding_period_years=H
+    )
+    assert res.feasible
+    assert res.weights  # not an empty book
+    assert abs(sum(res.weights.values()) - 1.0) < 1e-6
+    assert np.isfinite(res.diagnostics["linear_cost"])

--- a/tests/test_risk.py
+++ b/tests/test_risk.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from src.marketdata.client import MarketDataClient
 from src.risk import LedoitWolfCovariance, RiskMatrix, SampleCovariance, build_risk_matrix
@@ -158,3 +159,50 @@ def test_compute_risk_factor_model_reports_split():
     assert "factor_risk_share" in r
     assert abs(r["factor_risk_share"] + r["specific_risk_share"] - 1.0) < 1e-9
     assert set(r["factor_names"]) == {"market", "momentum", "volatility", "size"}
+
+
+def test_factor_exposures_subset_relaxes_history_requirement():
+    """A subset without momentum keeps names the full four-factor build must drop."""
+    from src.risk.exposures import build_factor_exposures
+
+    # ~90 bars: enough for volatility/size (60-bar windows), far short of 12-1 momentum.
+    bars = {s: make_ohlcv(n=90, seed=i, freq="1D") for i, s in enumerate(["AAA", "BBB", "CCC"])}
+    bench = make_ohlcv(n=90, seed=9, freq="1D")
+
+    full = build_factor_exposures(bars, bench)
+    subset = build_factor_exposures(bars, bench, factors=["market", "volatility", "size"])
+    assert full.empty
+    assert list(subset.index) == ["AAA", "BBB", "CCC"]
+    assert list(subset.columns) == ["market", "volatility", "size"]
+    # Cross-sectionally standardized: mean 0, unit dispersion per factor.
+    assert np.allclose(subset.mean().values, 0.0, atol=1e-12)
+    assert np.allclose(subset.std(ddof=0).values, 1.0, atol=1e-12)
+
+
+def test_factor_exposures_unknown_factor_raises():
+    from src.risk.exposures import build_factor_exposures
+
+    bars = {"AAA": make_ohlcv(n=200, seed=0, freq="1D")}
+    with pytest.raises(ValueError, match="value"):
+        build_factor_exposures(bars, None, factors=["market", "value"])
+
+
+def test_factor_exposures_empty_factor_list_returns_empty():
+    from src.risk.exposures import build_factor_exposures
+
+    bars = {s: make_ohlcv(n=200, seed=i, freq="1D") for i, s in enumerate(["AAA", "BBB"])}
+    assert build_factor_exposures(bars, None, factors=[]).empty
+
+
+def test_factor_exposures_reuse_precomputed_betas():
+    """A supplied beta Series is used verbatim for the market column (no re-regression)."""
+    from src.risk.exposures import build_factor_exposures
+
+    symbols = ["AAA", "BBB", "CCC"]
+    bars = {s: make_ohlcv(n=90, seed=i, freq="1D") for i, s in enumerate(symbols)}
+    bench = make_ohlcv(n=90, seed=9, freq="1D")
+    betas = pd.Series({"AAA": 0.5, "BBB": 1.0, "CCC": 1.5})
+    frame = build_factor_exposures(bars, bench, factors=["market"], betas=betas)
+    # Standardized column must be the z-score of the supplied betas exactly.
+    expected = (betas - betas.mean()) / betas.std(ddof=0)
+    assert np.allclose(frame["market"].reindex(symbols).values, expected.values)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -13,9 +13,16 @@ import pandas as pd  # noqa: E402
 
 from src.data import BarSource, ClientBarSource, ParquetBarStore  # noqa: E402
 from src.marketdata.client import MarketDataClient  # noqa: E402
+from src.marketdata.timeframe import Timeframe  # noqa: E402
 from tests.fakes import DictMarketData, make_ohlcv  # noqa: E402
 
 SYMBOLS = ["AAA", "BBB", "CCC"]
+
+#: The store normalises the timeframe to its canonical directory name (e.g. "1day"),
+#: which differs in case from the "1Day" people type. Derive it rather than hardcode
+#: the string so raw-path assertions match the on-disk layout on case-sensitive
+#: filesystems (Linux CI), not just case-insensitive ones (default macOS).
+TF_DIR = str(Timeframe.parse("1Day"))
 
 
 def _bars():
@@ -129,7 +136,7 @@ def test_streaming_backtest_matches_batch(tmp_path):
 def test_write_creates_year_partitions(tmp_path):
     store = ParquetBarStore(tmp_path)
     store.write(_multiyear_bars(start="2018-01-01", years=6), timeframe="1Day")
-    years = sorted(p.name for p in (tmp_path / "1Day" / "symbol=AAA").glob("year=*"))
+    years = sorted(p.name for p in (tmp_path / TF_DIR / "symbol=AAA").glob("year=*"))
     assert years == [f"year={y}" for y in range(2018, 2024)]  # one partition per calendar year
 
 
@@ -169,5 +176,5 @@ def test_rewrite_replaces_stale_year_partitions(tmp_path):
     store = ParquetBarStore(tmp_path)
     store.write(_multiyear_bars(start="2018-01-01", years=6), timeframe="1Day")
     store.write(_multiyear_bars(start="2022-01-01", years=1), timeframe="1Day")  # only 2022
-    years = sorted(p.name for p in (tmp_path / "1Day" / "symbol=AAA").glob("year=*"))
+    years = sorted(p.name for p in (tmp_path / TF_DIR / "symbol=AAA").glob("year=*"))
     assert years == ["year=2022"]

--- a/uv.lock
+++ b/uv.lock
@@ -552,6 +552,48 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/29/9bad86ed7aa812d8c822a27c15c355b6d5423b991feeec86ed18027b6daa/duckdb-1.5.4.tar.gz", hash = "sha256:f9e32f1cdd106793d79d190186bed9e75289d51e68bd9174e47c04bffedeab6f", size = 18046634, upload-time = "2026-06-17T10:48:52.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/ee/69340af74a3aa21838f14c16a0dd3e58461896ccba41f6bc7f0a01536e23/duckdb-1.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3ddd9533ce80f9b851bdd6276960a9286166514a9ceca43d5bc2f0d5842c490d", size = 32656177, upload-time = "2026-06-17T10:47:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/73/18/9da267ade389d4e7e533ac0c77b3a7041513a66efab93beb84f27627b0b8/duckdb-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:360f2542d09759c3739400f8b787e29b43ba0da665c21756216291458bf6fc59", size = 17318966, upload-time = "2026-06-17T10:47:33.688Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b4/ad73c1a396288e443b18af50819448060b318c1e933305167c1d7f98a507/duckdb-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0cf932055061e544d3fa27cc6c147da25f3f681ee5980157fb55e77d6c2d9c63", size = 15467572, upload-time = "2026-06-17T10:47:36.071Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/06/2c52ce3b97c3f21111f3c98a2121ed002e33f86488f55098a37825af6d4a/duckdb-1.5.4-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2d58d39f5e65419cdc27e3875cba4a729a3bbf6bf4016aefb4a2a65335a1d42", size = 19344044, upload-time = "2026-06-17T10:47:38.174Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/7d/5c0cc66fb90a1b14474eebb5ab535eacc51cb20b0e45358348b51c07abc9/duckdb-1.5.4-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9a10dc40469b9c0e458625d2a8359461a982c6151bb53ff259fea00c4695ad4", size = 21448215, upload-time = "2026-06-17T10:47:40.617Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/16c3ea201855cdfb7dde52ea3678d0536861cb485ffad46cf345436d658d/duckdb-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:3565550adbf160ef7a2ee3395470570182f11233983ad818bd7d5f9e349f92b2", size = 13132138, upload-time = "2026-06-17T10:47:43.085Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bb/7921dabd50daef3969f14cd8a5a14c24eee337db7914a462f2defa8add92/duckdb-1.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3fb41d9cfccb7e44511eeeed263ae98143ca63bdb1ef84631ba637c314efa1b5", size = 32663142, upload-time = "2026-06-17T10:47:45.471Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/83/2137765eaba6a9aefe3bb9848ddaac7407fe3ba19b292f98b31f3b7ab27f/duckdb-1.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:8ba7b666bc9c78d6a930ee9f469024149f0c6a23fb7d2c3418aad6774339bec0", size = 17321485, upload-time = "2026-06-17T10:47:47.778Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b2/a02c1ee43fd7e8cf1fc2e3d377f3dcf9d4a3e58a4549557516e1866ff0da/duckdb-1.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9d9e6817fcbc09d2605a2c8c041ac7824d738d917c35a4d427e977647e1d7944", size = 15470820, upload-time = "2026-06-17T10:47:49.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/48/a243d30223b024bc6057abe472b002cff01e97efefb4d2f0b0dcc5aece0b/duckdb-1.5.4-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02dd9f9a6124069213f13e3a474c208028c472fe1acdae12b38761f954fe4fc6", size = 19341849, upload-time = "2026-06-17T10:47:52.205Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ff/a5d48de4771e2403a8ef26a20dc7457b1c8f7e398ff0caf9c0cad8805f89/duckdb-1.5.4-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccc7f2694d02b4763fee61021d45e12f7bc5743993686563957df0cef799fbae", size = 21451698, upload-time = "2026-06-17T10:47:54.653Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/8244d7741b4afae67775cf0cb0d4eb9e923a83110907e4801e17fa078480/duckdb-1.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:4c430e788d99b50854209bf2833ba36a45df75e57f86efb477046cd408bbd077", size = 13132643, upload-time = "2026-06-17T10:47:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/57/8169822a37f6dd7d561c567f9007e3cf04bf97bccb619afe90db849c0962/duckdb-1.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:e2dc8340cfb6006025a798c50f40126d6e945a1d2487be94667bb4166556ce7b", size = 13986386, upload-time = "2026-06-17T10:47:59.345Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f2/e2f4b477ae3a3b40e8b5f429832e48edb62ed9da99807cc4902e157e5646/duckdb-1.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:291a9e7502551170af989ff63139a7a49e99d68edbc5ef5017ac27541fe54c65", size = 32708876, upload-time = "2026-06-17T10:48:01.527Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/2b/b698d82a5e1e30b6a05748d72045f672994c6b22f4f0f8423523608b991f/duckdb-1.5.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:83e8c089bbb756ca4471d8b05943b80a106058697cf00615e70423106bb783bc", size = 17346125, upload-time = "2026-06-17T10:48:04.035Z" },
+    { url = "https://files.pythonhosted.org/packages/71/75/37e13f39268eaf34864453b3a039c4a1ff0b088d3eae45a4289b41c98c1b/duckdb-1.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff96d2a342b200e1ec6f1f19986c77f4ac16a49b6112f71c5b763989203a9d60", size = 15488133, upload-time = "2026-06-17T10:48:06.312Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/59/2d082af578f689231798245b54562c61416e49049b0bda81a06c56a4b53e/duckdb-1.5.4-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f935ef210ab00bc94bb1e3052697adaa36bb0ce7bdfeda8b0f34e2ff1643870", size = 19367895, upload-time = "2026-06-17T10:48:08.59Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2b/55c34d2863a76ca824ef8274691e84240b4ff1acde3d231709e82557c240/duckdb-1.5.4-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0cda263d8c20addb8d4f95464787cbe0af1144f7ab7e21db3709fb826ee01725", size = 21486499, upload-time = "2026-06-17T10:48:10.963Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/30/ade5952b8182fac86fab43b95ebe3836e66381d0ad64eb1e54bd8207c988/duckdb-1.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:266c7c909558ce7377f57d082cee408aadebdd9111be017558ca54e44a031037", size = 13147934, upload-time = "2026-06-17T10:48:13.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/278f0f70e25b9911afe2fd227b9460f2e6d76177f0dcc03f7f1454afefa5/duckdb-1.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:f14e79a006341f29ee5a2692a24dac5114e77533d579c57ec39124adf0135033", size = 13965235, upload-time = "2026-06-17T10:48:15.782Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/3fcb34e523a9bad1f0557a6c7691a71ba66c43a05e5be9ee96a9a841ed65/duckdb-1.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:42a612e67d64450b446eb69695290d460713eef46e0f64467ab9dfe96264ee05", size = 32708366, upload-time = "2026-06-17T10:48:18.084Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/bff5054c2c1d65decab36aa6296621e51a2a575a9f250db7ab9b83a325d6/duckdb-1.5.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:3fb6f07d54ecf4d0d3c5179a2361fdddfafa14de4fc42696de4632479b703421", size = 17345735, upload-time = "2026-06-17T10:48:20.67Z" },
+    { url = "https://files.pythonhosted.org/packages/93/12/d1b2b344e9699246aada6f9de5156e708fb476e2780e5bff9b5d95fe11d9/duckdb-1.5.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0f32ad7e0286c1c29ab6c73b29118c86101f8eee46aae54f54d0b50916f542f6", size = 15488568, upload-time = "2026-06-17T10:48:23.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/ac56c6096e3e95da60b2c5dd5a0f0eb5540a80622e2e4f8faab893ec4e96/duckdb-1.5.4-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:698ec90bd5d5538bd5f6d212a4b61af443d240703cf45f134738535026556ea5", size = 19368184, upload-time = "2026-06-17T10:48:25.601Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/2ae4c3e157a19d9b4ac1f09a5dea6f93012334cc2db09f1e0c71eb99693d/duckdb-1.5.4-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136cea7f886b78caf4035485b4b1e766e8b309e999f9e83a966f81ebb8122844", size = 21486523, upload-time = "2026-06-17T10:48:27.817Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7b/c3d8d21e0d0db8faa81eeeb3a55b9932f5a0a16466cb968dc713a653d701/duckdb-1.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:bd6777e8ddd74fb603a6d09766bfcff28638189f8aaa61fc0dffd9e9a4baa8e5", size = 13147807, upload-time = "2026-06-17T10:48:30.017Z" },
+    { url = "https://files.pythonhosted.org/packages/44/48/ddf8d3740e3d28582944f70d84e720b5dc28c10ec22b668a0e0bd965f2f2/duckdb-1.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:73f4878a3012283024a64a1909e440aac12091ef336f671fc142f7e87449ce0c", size = 13965189, upload-time = "2026-06-17T10:48:32.251Z" },
+    { url = "https://files.pythonhosted.org/packages/62/01/67ac4cbc8e552a1e14c029b5c443d828e68f94d5d913c574f577e1db277e/duckdb-1.5.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4647968629d0677bbcc2416c7aeda8685eb84e4ca15a6dbd4f82a66cfc91a532", size = 32714364, upload-time = "2026-06-17T10:48:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/0e/eb44d983fa56b175f971eea251bde284a36d26cbb93fcb68035061f54078/duckdb-1.5.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e8fcef301cf68d3951ea1eb8ac4d76cea0a6f6a08f4c78fe4026fc96d217bebc", size = 17349820, upload-time = "2026-06-17T10:48:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b2/b9dc7624b105d414585b8530451c1162c0b4750c0be9be2e497bb47a8a9b/duckdb-1.5.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f6f39cd0dc6948dee17fd130aec55114f97a8ef6e1db519b9774087962bc5c8c", size = 15498160, upload-time = "2026-06-17T10:48:40.032Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/61356444f6a8c62dec3c3d129abfc53f428de1d484093d1bb381db441231/duckdb-1.5.4-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:262f068158beb5943f2c618f4e54b46db8306b959f90dce956f90a89f613673d", size = 19374183, upload-time = "2026-06-17T10:48:42.698Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/f4/d5d633dd7c5138d8f7c434e6ac2553c831b7fb658494efa8d0bc73df8623/duckdb-1.5.4-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d2307a76d199077b0055b354e90e857479461a0d875437535dd4833172c8b6d", size = 21487202, upload-time = "2026-06-17T10:48:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/26/5be13bbd5c3421dccfc1ad4ca9da4b97c5a3ddd73f66542092f3167ec52c/duckdb-1.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:6dcbb81a1276bc48deb4d562bce4f8895e4fc6348750a096e30052345c6d6552", size = 13666989, upload-time = "2026-06-17T10:48:47.764Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/4d52f3f9f9703a226b26b80bdae3f6905aeefe5221bf1815fc93ff02ca25/duckdb-1.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:0f8722346024e5d9f02b58bf7b0491a629f97fdc8a04a10e432940f471ee387a", size = 14449863, upload-time = "2026-06-17T10:48:50.18Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1678,6 +1720,34 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/99/fe77f10a13a778705ef05b499fc708c9a0b0a3680d9eb6bc6e1b6a6b9914/polars-1.42.1.tar.gz", hash = "sha256:2fe94f3059334650bd850ae19a9c165dcd5d9cb12cd95ea04de2201662e70e8a", size = 741532, upload-time = "2026-06-30T04:57:51.504Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/6a/edd939cc6fa04b6415aaa9bf19720fc74ead81234b3d38542e0005816d4d/polars-1.42.1-py3-none-any.whl", hash = "sha256:3c0c65cdfa21a621650c4bdcbbccf93964d052fd766c3e70e84a55d961c259fd", size = 837622, upload-time = "2026-06-30T04:56:34.686Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/59/15bcc4dac380c6d63efa5446d8317f22671cbd6c9dadd576bd17a334c45a/polars_runtime_32-1.42.1.tar.gz", hash = "sha256:4d4809e1c1b9a6611f6944f27b24abea902b5159e6b6fa262fd716e947af5afd", size = 3045460, upload-time = "2026-06-30T04:57:52.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/29/16ff6e4e91d71e530d3581f45e342a9cc35072ac6b31dcbc2fa33de2569e/polars_runtime_32-1.42.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:bbdc26d68ee5b23b0ce227fa0599220aa35b77c826b6b0a6b2d8e7f6c1c36974", size = 53117325, upload-time = "2026-06-30T04:56:37.972Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8e/4f8296fcfd1347f1351342fecf13bf2430d7efbae2f1f45964ec7930a99e/polars_runtime_32-1.42.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f6c0288be940b607dc4a7476c01e67fb6bbee93f5f1dd42c64970274c71008ba", size = 47446251, upload-time = "2026-06-30T04:56:41.459Z" },
+    { url = "https://files.pythonhosted.org/packages/88/2e/0d66a7deadc453b890c3391034ca8ab4b05d0beaebbb92a7d65199fba61b/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635d9dbcae2302ae223afb395d5cd220bffa61a53d0ab6871d17c8bc830101cf", size = 51359402, upload-time = "2026-06-30T04:56:44.595Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/10/ffb85fa380bc9c9000dc35f40f44954dde49023018501c54faab94b3a39e/polars_runtime_32-1.42.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d059e8e53cc114ff82f9bd791fd341dc53534a2c745e6f6aa37594c3a93f01fe", size = 57302723, upload-time = "2026-06-30T04:56:47.609Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/63/ca50adc62e44224ca5c622a842ba6f35ee87d1d40ef0df7ea2ed6c6edb08/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f91f0b13588324905682809d270e1de5f1990c908721c8527657d77a044c9919", size = 51515673, upload-time = "2026-06-30T04:56:50.88Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c3/08fbbf38deaa17bf34a601d327cb7451074098673c78b7c1a8538dde9794/polars_runtime_32-1.42.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b8bf972d99d48aaaa2582e2bce966a6f43bc815bd8725d15f5cab9e2fb15d17", size = 55217259, upload-time = "2026-06-30T04:56:53.834Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/0e/51db89361668fe077a835fc579277f824ba526e7daf7b94d23d25439e0d0/polars_runtime_32-1.42.1-cp310-abi3-win_amd64.whl", hash = "sha256:e9364c26da389a8b7339e4d29e20a3d12af730247e6ed3b7804bddce2477f428", size = 52715432, upload-time = "2026-06-30T04:56:57.109Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/2fb8592d691bd114de25d9c84300b23541dca7060eac11d7b4bed0327786/polars_runtime_32-1.42.1-cp310-abi3-win_arm64.whl", hash = "sha256:7051226e6b42ffc395a7a9190377cd28649fbfb991b8f85c6271f4e1cfb736fb", size = 46718300, upload-time = "2026-06-30T04:56:59.855Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2712,7 +2782,7 @@ wheels = [
 
 [[package]]
 name = "tradeflow"
-version = "0.2.0"
+version = "0.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alpaca-py" },
@@ -2728,9 +2798,11 @@ ai = [
     { name = "anthropic" },
 ]
 dev = [
+    { name = "duckdb" },
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "ortools" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "pytest" },
     { name = "ruff" },
@@ -2751,6 +2823,8 @@ portfolio = [
     { name = "ortools" },
 ]
 store = [
+    { name = "duckdb" },
+    { name = "polars" },
     { name = "pyarrow" },
 ]
 viz = [
@@ -2762,6 +2836,8 @@ viz = [
 requires-dist = [
     { name = "alpaca-py", specifier = ">=0.35" },
     { name = "anthropic", marker = "extra == 'ai'", specifier = ">=0.40" },
+    { name = "duckdb", marker = "extra == 'dev'", specifier = ">=1.0" },
+    { name = "duckdb", marker = "extra == 'store'", specifier = ">=1.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = ">=3.8" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
@@ -2770,6 +2846,8 @@ requires-dist = [
     { name = "ortools", marker = "extra == 'dev'", specifier = ">=9.8" },
     { name = "ortools", marker = "extra == 'portfolio'", specifier = ">=9.8" },
     { name = "pandas", specifier = ">=2.0" },
+    { name = "polars", marker = "extra == 'dev'", specifier = ">=1.25" },
+    { name = "polars", marker = "extra == 'store'", specifier = ">=1.25" },
     { name = "pyarrow", marker = "extra == 'dev'", specifier = ">=14" },
     { name = "pyarrow", marker = "extra == 'store'", specifier = ">=14" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },

--- a/website/docs/engineering/alphas.md
+++ b/website/docs/engineering/alphas.md
@@ -67,16 +67,52 @@ model, so the scaling identity and the as-of discipline live in exactly one plac
 
 Alphas should be **benchmark-neutral** — the equal-weighted average alpha ≈ 0 — so
 they express only *relative* views and don't smuggle in a directional market bet.
-Two levers, both in `refine.neutralize` (an OLS residual, orthogonal to the supplied
-exposures by construction, with an intercept so the residual is mean-zero):
+Two levers, both ending in `refine.neutralize` (an OLS residual, orthogonal to the
+supplied exposures by construction, with an intercept so the residual is mean-zero):
 
-- **Benchmark-beta neutral** (always available): regress `z` on each name's beta and
-  keep the residual. Enabled by `--neutralize`.
-- **Factor neutral** (when a factor risk model exists): regress on the
-  factor-exposure matrix so the alpha is orthogonal to size/momentum/vol.
+- **Benchmark-beta neutral**: regress `z` on each name's beta and keep the residual.
+  Enabled by `--neutralize`.
+- **Factor neutral**: regress on the [risk model's](./risk-model.md) standardized
+  factor exposures (`exp_<factor>` panel columns, written by
+  `add_factor_exposure_features` from the *same* builder the factor risk model uses —
+  one definition of "factor", both places). Enabled by `--neutralize-factors`; the
+  bare flag neutralizes **market, volatility, size**. **Momentum is deliberately not
+  in the default set** — a momentum tilt is a return bet the alpha may intend;
+  regress it out explicitly (`--neutralize-factors market,volatility,size,momentum`)
+  if that's the goal.
 
 The z-score already centres the cross-section at 0, so equal-weight benchmark
 neutrality holds even before the explicit step.
+
+Both levers compose into **one regression on the union** of exposures, with three
+rules that keep degraded inputs honest rather than silently wrong:
+
+1. **Usability gating.** A factor column is used only if it exists and actually
+   varies across covered names. An absent, all-NaN, or constant column (e.g. the
+   exposure build qualified fewer than two names on a short-history universe)
+   **degrades to plain-beta neutralisation — never to no neutralisation**.
+2. **Mean-imputation for partial coverage.** A name missing one factor value gets
+   the cross-sectional mean (0 — exposures are standardized), keeping it *in* the
+   regression. Without this, the union's row-wise NaN-drop would strip that name's
+   beta neutralisation too, and the cross-section would silently mix neutralized and
+   raw scores.
+3. **Report what was applied, not what was asked.** The refinement records
+   `panel.meta["neutralized_against"]` (and an imputation count); the services echo
+   it as `neutralized_against`, and the CLI prints it — with an explicit warning when
+   a requested factor's exposures were unavailable. "Factor-neutral" is never claimed
+   for un-neutralized output.
+
+:::note Known limitations (deliberate, tracked)
+- The **MCP tools don't expose `neutralize_factors` yet** — results echo the field
+  (always `[]` via that surface); wiring the parameter through
+  [`src/mcp/server.py`](./mcp-server.md) is a small follow-up for when the agent
+  surface needs it.
+- The exposure builder's **history gate is two-way, not per-factor**: a subset with
+  momentum requires the full 12-1 window (~148 bars), any other subset requires
+  `vol_window + 1` (61) bars — even for factors (like market) that could tolerate
+  less. Names between those bounds are dropped from the exposure frame (then
+  mean-imputed per rule 2).
+:::
 
 ## The feature panel and refinement
 

--- a/website/docs/engineering/data-panel.md
+++ b/website/docs/engineering/data-panel.md
@@ -68,7 +68,7 @@ Each module is a column producer, a consumer, or both:
 | Producer | Writes |
 |----------|--------|
 | `add_risk_features` | `beta`, `residual_vol` (annualised; falls back to total vol with no benchmark) |
-| `add_factor_exposure_features` | `exp_<factor>` (the [risk model's](./risk-model) standardized exposures, for [factor-neutral alphas](./alphas#neutralization); reuses the panel's `beta`, writes nothing if <2 names qualify) |
+| `add_factor_exposure_features` | `exp_<factor>` (the [risk model's](./risk-model) standardized exposures, for [factor-neutral alphas](./alphas#neutralization); reuses the panel's `beta`, writes nothing if `<2` names qualify) |
 | `add_score_feature` | `score` (applies any `scorer`: a strategy, a scanner, …) |
 
 | Consumer | Reads → writes |

--- a/website/docs/engineering/data-panel.md
+++ b/website/docs/engineering/data-panel.md
@@ -68,14 +68,16 @@ Each module is a column producer, a consumer, or both:
 | Producer | Writes |
 |----------|--------|
 | `add_risk_features` | `beta`, `residual_vol` (annualised; falls back to total vol with no benchmark) |
+| `add_factor_exposure_features` | `exp_<factor>` (the [risk model's](./risk-model) standardized exposures, for [factor-neutral alphas](./alphas#neutralization); reuses the panel's `beta`, writes nothing if <2 names qualify) |
 | `add_score_feature` | `score` (applies any `scorer`: a strategy, a scanner, …) |
 
 | Consumer | Reads → writes |
 |----------|----------------|
-| `refine_alpha` ([alphas](./alphas)) | `score`, `residual_vol`, `beta` → `z`, `alpha` |
+| `refine_alpha` ([alphas](./alphas)) | `score`, `residual_vol`, `beta`, `exp_*` → `z`, `alpha` (+ `meta.neutralized_against`) |
 
-New producers (factor exposures, transaction-cost params, liquidity) slot in the same
-way, and consumers downstream don't change.
+New producers (transaction-cost params, liquidity) slot in the same way, and
+consumers downstream don't change — the factor-exposure producer arrived exactly
+this way.
 
 ## Why it's shaped this way
 

--- a/website/docs/engineering/mcp-server.md
+++ b/website/docs/engineering/mcp-server.md
@@ -54,8 +54,18 @@ service function, logs the call, and returns JSON. The exposed surface:
 - Discovery: `list_strategies`, `list_scanners`, `get_param_ranges`
 - Analyze: `run_scan`, `run_backtest`, `run_optimization`, `run_walk_forward`,
   `get_metrics_glossary`, `summarize_bars`
+- Research: `compute_alphas`, `combine_alphas`, `compute_risk`,
+  `construct_portfolio`, `compute_information`, `compute_horizon`
 - Propose (writes a file, never live state): `save_config`, `load_config`,
   `list_configs`
+
+:::note Known gap
+The research tools don't expose the CLI's `neutralize_factors` parameter yet
+([factor-neutral alphas](./alphas.md#neutralization)) — their results echo a
+`neutralized_against` field, but via this surface it is always empty. Wiring the
+parameter through the tool signatures is a small follow-up for when the agent
+surface needs it.
+:::
 
 ## The hard wall
 

--- a/website/docs/engineering/risk-model.md
+++ b/website/docs/engineering/risk-model.md
@@ -66,6 +66,15 @@ Two estimators behind one `RiskModel.estimate(returns)` interface:
   *factor* risk (`w_aᵀ X F Xᵀ w_a`) and *specific* risk (`w_aᵀ Δ w_a`). `risk --model
   factor` reports that split; it's what makes performance attribution possible.
 
+  The exposure builder (`build_factor_exposures`) is also the source of the
+  [alpha pipeline's](./alphas.md#neutralization) factor-neutralization columns — one
+  definition of "factor", both places. For that use it accepts a **subset**
+  (`factors=[...]`, relaxing the history requirement when momentum isn't requested)
+  and **precomputed betas** (`betas=...`, so the market column reuses the panel's
+  beta regression instead of rerunning it per name). Known limitation: the history
+  gate is two-way (momentum ⇒ ~148 bars, otherwise 61), not per-factor — a
+  market-only subset still requires 61 bars.
+
 ## Edge cases it handles
 
 - **Invertibility is the whole point.** Every estimator returns a positive-definite

--- a/website/docs/usage/alphas.md
+++ b/website/docs/usage/alphas.md
@@ -45,6 +45,7 @@ residual return for the year. The ranking is what a mean-variance
 | `--ic` | `0.03` | Assumed information coefficient (sets overall aggressiveness). |
 | `--benchmark` | `SPY` | Benchmark for beta and residual volatility. |
 | `--neutralize` | off | Make alphas beta-neutral (regress out benchmark beta). |
+| `--neutralize-factors` | off | Make alphas **factor-neutral**: regress out the risk model's exposures. Bare flag = `market,volatility,size` (momentum kept — a momentum tilt is a return bet the alpha may intend); or pass a comma-separated subset. |
 | `--lookback-days` | `180` | History fetched (≤ `as_of`) for the residual-vol estimate. |
 
 Use `--source scanner` to rank by a scanner's continuous conviction instead of the
@@ -53,6 +54,35 @@ strategy's score:
 ```bash
 python main.py alphas --source scanner --scanner volume --symbols NVDA,AAPL,META --as-of 2025-06-01
 ```
+
+## Factor-neutral alphas
+
+`--neutralize-factors` regresses the scores against the
+[risk model's](../engineering/risk-model.md) standardized factor exposures, so the
+alphas can't hide an incidental market/volatility/size tilt:
+
+```bash
+python main.py alphas --strategy volume_spike --symbols ... --neutralize-factors
+```
+
+The report states what was **actually applied** — and warns when it couldn't be:
+
+```
+Alphas from 'volume_spike' score as of 2025-06-01 (IC=0.03, benchmark=SPY)
+  neutralized against: market, volatility, size
+```
+
+```
+  neutralized against: beta
+  ! requested factor(s) NOT neutralized (exposures unavailable — insufficient history?): market, volatility, size
+```
+
+The second form appears when the universe's history is too short to build the
+exposures (momentum needs ~148 daily bars, the others 61) — the pipeline then falls
+back to plain-beta neutralisation rather than silently doing nothing. Unknown factor
+names are rejected at parse time. The same flag exists on `allocate --objective
+utility` (construct from factor-neutral alphas) and on `info`/`horizon` — **measure
+the same alpha you deploy**. Note: the MCP tools don't expose this parameter yet.
 
 ## Combining several signals
 

--- a/website/docs/usage/information.md
+++ b/website/docs/usage/information.md
@@ -46,6 +46,7 @@ how inflated a "significant" result is once you account for everything you tried
 | `--benchmark` | `SPY` | Used to strip beta (residual returns). |
 | `--horizon` | `5` | Forward-return horizon, in bars. |
 | `--n-trials` | `1` | Configs tried, for the multiple-testing inflation. |
+| `--neutralize-factors` | off | Measure the **factor-neutral** alpha (bare flag = `market,volatility,size`) — use the same setting you deploy with, so the measured IC/IR describes the forecast you actually trade. Also on `horizon`. |
 
 ## What it does (and doesn't) tell you
 

--- a/website/docs/usage/portfolio.md
+++ b/website/docs/usage/portfolio.md
@@ -77,3 +77,8 @@ this Σ; the **transfer coefficient** is how much of it survives your constraint
 (tighten `--max-names` or `--max-weight` and watch it fall); **predicted IR** ≈
 `TC · IR*`. See [Portfolio construction (engineering)](../engineering/portfolio-construction)
 for the math.
+
+`--neutralize-factors` builds the book from **factor-neutral alphas** (bare flag =
+`market,volatility,size`; momentum kept as a deliberate return tilt) — see
+[Ranking by alpha](alphas#factor-neutral-alphas) for the semantics and the
+honesty warning when exposures are unavailable.


### PR DESCRIPTION
## Summary

Two pieces of the active-management spine: **spec 016 — cost-aware portfolio optimization** (transaction cost moves from an ex-post report *into* the objective), and **factor-neutral alphas** (scores can be regressed against the risk model's exposure block, not just benchmark beta).

### Cost inside the objective (spec 016)

The optimizer now solves

```
max  αᵀw − λ·wᵀΣw − Σ cᵢ|Δwᵢ| − Σ kᵢ|Δwᵢ|^{3/2}    (Δw = w − w₀)
```

so it trades a name's alpha against *that name's* cost and finds the genuinely net-optimal book.

- **Solved exactly in pure numpy** — no conic solver, no new dependency. The proximal operator of the full cost (linear + √-impact) separates per name given the budget dual and is closed-form per coordinate: a soft-threshold around `w₀` for the linear term (this is where the **no-trade band emerges from cost itself**) and a quadratic-in-√ root for the impact term, composed with the same budget bisection the cost-free projection used. With zero cost the solve reduces byte-for-byte to spec 008.
- **Per-name cost inputs**, as-of: spread proxy from the trailing high-low range (clamped), trailing dollar ADV; `kᵢ = η·σᵢ·√(capital/ADV$ᵢ)`, annualised by holding period. The optimizer and the backtest price the same cost model.
- **Two cost figures, honestly labeled**: the headline `expected_active_return_net` subtracts a **round-trip** haircut on the held book (enter *and* exit, amortised — agrees with the capacity number); the detail figures keep the **one-way** cost of this rebalance's turnover, exactly what the objective charged.
- `allocate --objective utility` is **cost-aware by default** (`--gross-objective` to toggle); verified by a KKT optimality certificate, brute-force checks of the per-name prox, and the spec's test checklist.

### Factor-neutral alphas

The refinement pipeline can neutralize scores against the factor risk model's standardized exposures (`--neutralize-factors` on `alphas`/`allocate`/`info`/`horizon` — measure the same alpha you deploy). Bare flag = market/volatility/size; momentum is deliberately kept (a momentum tilt is a return bet the alpha may intend). One definition of "factor": the exposure builder is the same one behind Σ = XFXᵀ + Δ, now supporting factor subsets and beta reuse.

Degradation is honest, never silent — hardened by an 8-angle adversarial review that caught and fixed two real bugs in the first cut:

- An absent, all-NaN, or constant exposure column **falls back to plain-beta neutralization** (previously: requested market neutrality on a short-history universe silently lost *all* neutralization).
- Names missing one factor value are **mean-imputed (0 — exposures are standardized)** so they stay in the regression (previously: the union's NaN-drop stripped their beta neutralization too).
- The report prints what was **applied** (`neutralized_against`) and warns when a requested factor's exposures were unavailable; unknown factor names are rejected at parse time.

Known gaps, documented in the engineering docs: the MCP research tools don't expose `neutralize_factors` yet, and the exposure history gate is two-way (momentum ⇒ ~148 bars, otherwise 61), not per-factor.

### Docs

Usage (alphas/portfolio/information) and engineering (alphas/risk-model/data-panel/mcp-server — including the previously stale MCP tool list) pages updated; MDX compilation fix.

### Verification

314 tests pass (7 new unit/regression tests + a service-level end-to-end for factor-neutral alphas; KKT certificate + prox brute-force for the cost-aware solve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)