### PR TITLE
Forecast refinement v2: case scaling, IC-uncertainty level shrink, equal-risk monitor

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,42 @@
+name: Docs
+
+# Lints the documentation site by building it: the Docusaurus production build
+# compiles every Markdown/MDX page and (with onBrokenLinks/onBrokenAnchors set to
+# 'throw' in docusaurus.config.js) fails on any dead internal link or anchor.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: website
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs (fails on broken links/anchors)
+        run: npm run build

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -156,6 +156,11 @@ Default checklist for every change.
 - **Code must be self-contained: never reference specs or planning docs in code.**
   A comment should explain the behavior on its own terms; if it needs to point
   somewhere, link to the engineering wiki — never to a planning spec.
+- **No external-source citations in code or docs.** Explain the math and the
+  reasoning directly; do not name the book, paper, author, or equation/table number
+  a technique came from (e.g. no "G&K 11.32", no "per Chapter 11"). Cite the concept
+  (`the IC-uncertainty level shrink`), not its provenance. Identifiers in output
+  (e.g. a `shrink_chain` `owner`) follow the same rule — use a descriptive name.
 
 ### Review after every change
 

--- a/main.py
+++ b/main.py
@@ -484,6 +484,7 @@ def cmd_alphas(args) -> None:
         neutralize=args.neutralize,
         neutralize_factors=args.neutralize_factors,
         lookback_days=args.lookback_days,
+        scaling=args.scaling,
     )
 
     src_desc = {
@@ -493,6 +494,7 @@ def cmd_alphas(args) -> None:
     }[args.source]
     print(f"\nAlphas from {src_desc} as of {args.as_of:%Y-%m-%d} (IC={args.ic}, benchmark={args.benchmark})")
     _print_neutralization(result)
+    _print_case(result)
     if not result["benchmark_available"]:
         print("  ! benchmark unavailable — residual vol falls back to total volatility")
     if result["low_confidence"]:
@@ -526,6 +528,21 @@ def _print_neutralization(result) -> None:
             f"  ! requested factor(s) NOT neutralized (exposures unavailable — "
             f"insufficient history?): {', '.join(missing)}"
         )
+
+
+def _print_case(result) -> None:
+    """One line on the chosen scaling and the Case test, when it ran."""
+    case = result.get("case")
+    if not case:
+        if result.get("scaling") and result["scaling"] != "case1":
+            print(f"  scaling: {result['scaling']}")
+        return
+    amb = " (ambiguous → base rate)" if case.get("ambiguous") else ""
+    print(
+        f"  scaling: {result['scaling']} — Case {case['case']}{amb} "
+        f"(R²={case['r_squared']:.2f}, t={case['t_stat']:+.1f}, "
+        f"candidate corr {case.get('candidate_correlation', float('nan')):.2f})"
+    )
 
 
 def _print_combined_alphas(result, args) -> None:
@@ -604,6 +621,11 @@ def cmd_info(args) -> None:
     from src.services.analysis import compute_information
 
     _, data_client = build_data_and_broker()
+
+    if getattr(args, "scaling_ab", False):
+        _print_scaling_ab(data_client, args)
+        return
+
     r = compute_information(
         data_client,
         args.strategy,
@@ -641,10 +663,66 @@ def cmd_info(args) -> None:
         f"  attribution: factor {r['factor_return']:+.4f} / specific {r['specific_return']:+.4f} "
         f"per rebalance (factor tilts vs name selection)"
     )
+    # IC-uncertainty level shrink: how much of the measured IC level survives its own
+    # estimation error, with an overlap-honest effective T.
+    if "level_shrink_factor" in r:
+        print(
+            f"  level shrink: keep {r['level_shrink_factor']:.0%} of the naive level "
+            f"(T_eff {r['effective_t']:.1f}, IC {r['recommended_ic']:+.4f})"
+        )
+    _print_bucket_diagnostic(r.get("risk_bucket_diagnostic"))
     verdict = "distinguishable from luck" if abs(r["ic_tstat"]) >= 2 else "NOT distinguishable from luck"
     print(f"\n  Verdict: skill is {verdict} (IC t-stat {r['ic_tstat']:+.2f}).")
     if abs(r["ic_tstat"]) >= 2:
         print(f"  Recommended IC for alpha scaling (a human applies it): {r['recommended_ic']:.4f}")
+        print(
+            f"  After the IC-uncertainty level shrink, deploy IC ≈ "
+            f"{r['recommended_ic'] * r.get('level_shrink_factor', 1.0):.4f}"
+        )
+
+
+def _print_bucket_diagnostic(diag) -> None:
+    """The equal-risk-contribution check, when it engaged."""
+    if not diag or not diag.get("engaged"):
+        if diag and diag.get("reason"):
+            print(f"  risk buckets: suppressed — {diag['reason']}")
+        return
+    marker = "⚠ tilt" if diag["tilt_detected"] else "ok"
+    print(
+        f"  risk buckets ({diag['n_buckets']}, by residual vol): {marker} — "
+        f"variance-share gradient {diag['variance_share_gradient']:+.2f} "
+        f"vs band ±{diag['sampling_band']:.2f}"
+    )
+    if diag["tilt_detected"]:
+        print(f"    → {diag['verdict']}")
+
+
+def _print_scaling_ab(data_client, args) -> None:
+    """Walk-forward A/B of the two scalings (the `--scaling-ab` research mode)."""
+    from src.services.analysis import run_scaling_ab
+
+    r = run_scaling_ab(
+        data_client,
+        args.strategy,
+        args.symbols,
+        args.start,
+        args.end,
+        source=args.source,
+        scanner=args.scanner,
+        benchmark=args.benchmark,
+        neutralize_factors=args.neutralize_factors,
+        horizon=args.horizon,
+    )
+    if not r.get("periods"):
+        print(r.get("note", "No scaling A/B produced."))
+        return
+    print(f"\nScaling A/B: '{args.strategy}' {args.start:%Y-%m-%d}..{args.end:%Y-%m-%d}")
+    print(f"  measured over {r['periods']} rebalances (horizon {r['horizon_bars']} bars)")
+    print(f"  Case 1 (σ·IC·z) realized IR: {r['case1_realized_ir']:+.2f}")
+    print(f"  Case 2 (IC·c_g·z) realized IR: {r['case2_realized_ir']:+.2f}")
+    agree = "agree" if r["agree"] else "DISAGREE"
+    print(f"  regression picks {r['regression_pick']}, A/B picks {r['ab_pick']} — {agree}")
+    print("  (compare the IR gap to its standard-error band before acting — a small gap is noise)")
 
 
 def cmd_horizon(args) -> None:
@@ -1097,6 +1175,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     _add_neutralize_factors_flag(alphas)
     alphas.add_argument("--lookback-days", dest="lookback_days", type=int, default=180)
+    alphas.add_argument(
+        "--scaling",
+        choices=["case1", "case2", "auto"],
+        default="case1",
+        help="Per-name scaling: 'case1' = σ·IC·z (default); 'case2' = IC·c_g·z "
+        "(no per-name vol multiply); 'auto' = let a Std_TS-vs-ω regression decide",
+    )
     alphas.set_defaults(func=cmd_alphas)
 
     info = subparsers.add_parser(
@@ -1119,6 +1204,13 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=1,
         help="Configs tried (for multiple-testing inflation)",
+    )
+    info.add_argument(
+        "--scaling-ab",
+        dest="scaling_ab",
+        action="store_true",
+        help="Research mode: walk-forward the realized IR under Case-1 vs "
+        "Case-2 scaling and compare against the regression's pick",
     )
     _add_neutralize_factors_flag(info, note="; measure the alpha you deploy")
     info.set_defaults(func=cmd_info)

--- a/src/alphas/base.py
+++ b/src/alphas/base.py
@@ -17,7 +17,7 @@ places no orders.
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import List, Optional, Tuple
 
 import pandas as pd
 
@@ -63,6 +63,19 @@ class AlphaContext:
     winsorize_limits: tuple = (0.025, 0.975)
     alpha_cap_std: float = 3.0
     min_universe: int = DEFAULT_MIN_UNIVERSE
+    #: Per-name scaling. ``"case1"`` = the standard rule ``ω·IC·z`` (the default,
+    #: correct when per-name signal vol is constant across names); ``"case2"`` =
+    #: ``IC·c_g·z`` with a constant :func:`~src.alphas.refine.case_scale_factor`, for
+    #: signals whose vol is ∝ the name's residual vol (multiplying by ``ω_n`` would
+    #: double-count it). :func:`~src.alphas.refine.case_test` picks the case empirically.
+    #: See the Continuous-alphas page in the engineering docs for the Case test.
+    scaling: str = "case1"
+    #: IC-uncertainty **level** shrink. When set to ``(measured_ic, t_eff)`` the refined
+    #: alpha is multiplied once by :func:`~src.alphas.refine.level_shrink_factor` — the
+    #: estimation-error haircut on the *level*. ``None`` = off (a measured IC hasn't been
+    #: supplied, e.g. an assumed prior, or the level shrink is owned upstream by the
+    #: multi-signal combination's per-signal Bayesian shrink).
+    level_shrink: Optional[Tuple[float, float]] = None
 
 
 def refine_alpha(
@@ -127,12 +140,41 @@ def refine_alpha(
         ]
         panel.meta["neutralize_imputed"] = imputed
 
-    # 4. Scale to a residual-return forecast via alpha_i = sigma_i * IC * z_i.
+    # 4. Scale to a residual-return forecast. Case 1: alpha_i = sigma_i * IC * z_i
+    #    (per-name vol). Case 2: alpha_i = IC * c_g * z_i (one constant c_g), which
+    #    avoids double-counting vol for signals whose per-name vol is ∝ sigma_i.
     if panel.has("residual_vol"):
         vol = panel.get("residual_vol").reindex(z.index).fillna(context.default_residual_vol)
     else:
         vol = pd.Series(context.default_residual_vol, index=z.index)
-    alpha = refine.scale_to_alpha(z, vol, context.ic)
+
+    chain: List[dict] = []
+    if context.scaling == "case2" and not thin:
+        c_g = refine.case_scale_factor(s, vol, context.winsorize_limits)
+        if not (c_g == c_g):  # NaN fallback → a representative vol, so it never crashes
+            c_g = float(vol.mean())
+        alpha = refine.scale_to_alpha(z, pd.Series(c_g, index=z.index), context.ic)
+        chain.append({"step": "scale", "case": 2, "c_g": float(c_g), "multiplier": float(context.ic * c_g)})
+    else:
+        alpha = refine.scale_to_alpha(z, vol, context.ic)
+        chain.append({"step": "scale", "case": 1, "multiplier": float(context.ic)})
+
+    # 4b. IC-uncertainty level shrink, applied exactly once here — the single
+    #     application point for both the single-signal and combined paths.
+    if context.level_shrink is not None:
+        ic_measured, t_eff = context.level_shrink
+        factor = refine.level_shrink_factor(ic_measured, t_eff)
+        alpha = alpha * factor
+        chain.append(
+            {
+                "step": "ic_uncertainty",
+                "owner": "level_shrink",
+                "ic": float(ic_measured),
+                "t_eff": float(t_eff),
+                "multiplier": float(factor),
+            }
+        )
+    panel.meta["shrink_chain"] = chain
 
     # 5. Final sanity cap (meaningless on a thin, unscaled vector).
     if not thin:

--- a/src/alphas/horizon.py
+++ b/src/alphas/horizon.py
@@ -97,3 +97,20 @@ def recommended_cadence(ic_by_lag: Mapping[int, float]) -> int:
     """The cadence (in periods) that maximizes the IR proxy ``IC(Δt)·√(1/Δt)``."""
     curve = frequency_ir_curve(ic_by_lag)
     return max(curve, key=curve.get) if curve else 1
+
+
+def effective_sample_size(n_obs: float, horizon: int, spacing: float = 1.0) -> float:
+    """Effective *independent* observations when each spans ``horizon`` periods.
+
+    An IC measured from returns over a ``horizon``-period holding, sampled every
+    ``spacing`` periods, overlaps: consecutive observations share ``horizon − spacing``
+    periods of return and so are not independent. The independent count is
+    ``n_obs / overlap`` with ``overlap = max(1, horizon/spacing)`` — daily rows with a
+    21-day horizon (``spacing=1``) are ~21× overlapped, so ``T_eff ≈ n/21``; rebalances
+    already spaced ``≥ horizon`` apart (``spacing ≥ horizon``) are independent and
+    ``T_eff = n``. This is the honest ``T`` the IC-uncertainty shrink
+    (:func:`src.alphas.refine.level_shrink_factor`) needs: using the raw row count
+    under-shrinks by exactly the overlap factor.
+    """
+    overlap = max(1.0, horizon / max(spacing, 1e-9))
+    return float(n_obs / overlap) if overlap > 0 else float(n_obs)

--- a/src/alphas/refine.py
+++ b/src/alphas/refine.py
@@ -15,6 +15,8 @@ never across time for one name - standardizing over time would reintroduce the
 look-ahead this module exists to avoid.
 """
 
+import math
+
 import numpy as np
 import pandas as pd
 
@@ -100,11 +102,187 @@ def scale_to_alpha(z: pd.Series, residual_vol: pd.Series, ic: float) -> pd.Serie
     the alphas carry the right information ratio for a mean-variance optimizer to
     size positions by genuine conviction rather than by an arbitrary signal scale.
 
-    ``residual_vol`` is aligned to ``z`` by symbol.
+    ``residual_vol`` is aligned to ``z`` by symbol. This is the **Case 1** scaling
+    (see :func:`case_test`): correct when the signal's per-name time-series vol is
+    roughly constant across names, so the cross-sectional z equals the time-series z
+    the standard rule is stated in. For a **Case 2** signal pass a constant
+    :func:`case_scale_factor` as ``residual_vol`` instead of the per-name vector.
     """
     vol = residual_vol.reindex(z.index)
     # Evaluated as (sigma * IC) * z to match the written identity exactly.
     return vol * ic * z
+
+
+def case_scale_factor(
+    raw_scores: pd.Series,
+    residual_vol: pd.Series,
+    winsorize_limits: tuple = (0.025, 0.975),
+) -> float:
+    """The **Case 2** constant scale ``c_g = Std_CS{g} / Std_CS{g/ω}``.
+
+    A Case-2 signal (per-name signal vol ∝ the name's residual vol ``ω_n`` —
+    empirically most price/estimate signals) already carries the volatility inside
+    the raw score; multiplying by ``ω_n`` in :func:`scale_to_alpha` double-counts it
+    and tilts the book into high-vol names. The fix replaces the per-name ``ω_n`` with
+    one cross-sectional **constant** ``c_g`` (a vol-dimensioned, dispersion-matched
+    representative vol), so ``alpha = IC · c_g · z`` sizes by conviction without the
+    spurious vol tilt.
+
+    Computed on the **raw** signal (winsorized the same way the pipeline winsorizes),
+    because after standardization the raw dispersion that defines ``c_g`` is gone.
+    Returns NaN when the ratio can't be formed (too few names, all-zero vol) so the
+    caller can fall back.
+    """
+    g = raw_scores.dropna()
+    if len(g) < 2:
+        return float("nan")
+    g = winsorize(g, *winsorize_limits)
+    vol = residual_vol.reindex(g.index)
+    ratio = (g / vol.where(vol > 0)).replace([np.inf, -np.inf], np.nan).dropna()
+    num = g.std(ddof=0)
+    den = ratio.std(ddof=0)
+    if not np.isfinite(den) or den == 0:
+        return float("nan")
+    return float(num / den)
+
+
+def case_test(
+    signal_history: pd.DataFrame,
+    residual_vol: pd.Series,
+    *,
+    price_derived: bool = True,
+    min_obs: int = 36,
+    r2_case2: float = 0.25,
+    r2_case1: float = 0.05,
+    t_threshold: float = 2.0,
+) -> dict:
+    """Decide a signal's scaling: **Case 1** (``ω·IC·z``) vs **Case 2** (``IC·c_g·z``).
+
+    The standard refinement rule ``α = ω·IC·z`` is stated in *time-series* z-scores,
+    but the pipeline computes *cross-sectional* z. Whether the two coincide is an
+    empirical property of each signal:
+
+    - **Case 1** — per-name time-series signal vol ``Std_TS{g_n}`` is ~constant across
+      names ⇒ ``z_TS ≈ z_CS`` and the ``ω_n`` multiply is right (the classic
+      sector-momentum example).
+    - **Case 2** — ``Std_TS{g_n}`` is ~proportional to the name's residual vol ``ω_n``
+      (most price/estimate signals) ⇒ the vol is already inside the raw signal and the
+      ``ω_n`` multiply double-counts it.
+
+    The test regresses ``Std_TS{g_n} = a + b·ω_n`` across names: a strong, significant
+    positive slope ⇒ Case 2. ``signal_history`` is a time×name frame of the **raw**
+    signal; ``residual_vol`` the per-name ``ω_n``. Needs ``≥ min_obs`` time observations
+    to engage; below that (or in the ambiguous band ``r2_case1 < R² < r2_case2``) it
+    returns the empirical base rate — **Case 2 for price-derived signals, Case 1
+    otherwise** — flagged ``ambiguous`` so a wrong call is visible, not silent.
+    """
+    default_case = 2 if price_derived else 1
+
+    def _result(case, r2, t, slope, n_obs, n_names, engaged, ambiguous, reason):
+        return {
+            "case": case,
+            "r_squared": float(r2),
+            "t_stat": float(t),
+            "slope": float(slope),
+            "n_obs": int(n_obs),
+            "n_names": int(n_names),
+            "engaged": bool(engaged),
+            "ambiguous": bool(ambiguous),
+            "reason": reason,
+        }
+
+    if signal_history is None or signal_history.empty:
+        return _result(default_case, 0.0, 0.0, 0.0, 0, 0, False, True, "no signal history")
+
+    std_ts = signal_history.std(ddof=1)
+    counts = signal_history.count()
+    n_obs = int(counts.median()) if len(counts) else 0
+
+    aligned = pd.concat([std_ts.rename("y"), residual_vol.rename("x")], axis=1).dropna()
+    # A name needs enough time observations for its Std_TS to mean anything.
+    aligned = aligned[counts.reindex(aligned.index).fillna(0) >= min(min_obs, max(n_obs, 2))]
+    n_names = len(aligned)
+
+    if n_obs < min_obs or n_names < 3:
+        return _result(
+            default_case,
+            0.0,
+            0.0,
+            0.0,
+            n_obs,
+            n_names,
+            False,
+            True,
+            f"insufficient history (n_obs={n_obs} < {min_obs} or n_names={n_names} < 3); "
+            f"defaulting to Case {default_case} ({'price-derived' if price_derived else 'other'})",
+        )
+
+    x = aligned["x"].to_numpy()
+    y = aligned["y"].to_numpy()
+    xm, ym = x.mean(), y.mean()
+    sxx = float(((x - xm) ** 2).sum())
+    if sxx == 0:
+        return _result(default_case, 0.0, 0.0, 0.0, n_obs, n_names, False, True, "no ω dispersion")
+    slope = float(((x - xm) * (y - ym)).sum() / sxx)
+    resid = y - (ym + slope * (x - xm))
+    ss_res = float((resid**2).sum())
+    ss_tot = float(((y - ym) ** 2).sum())
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    dof = n_names - 2
+    se_b = math.sqrt((ss_res / dof) / sxx) if dof > 0 and sxx > 0 else float("inf")
+    t_stat = slope / se_b if np.isfinite(se_b) and se_b > 0 else 0.0
+
+    if r2 >= r2_case2 and t_stat >= t_threshold and slope > 0:
+        return _result(
+            2,
+            r2,
+            t_stat,
+            slope,
+            n_obs,
+            n_names,
+            True,
+            False,
+            f"Std_TS ∝ ω (R²={r2:.2f}, t={t_stat:.1f}): vol already in the signal",
+        )
+    if r2 <= r2_case1:
+        return _result(
+            1,
+            r2,
+            t_stat,
+            slope,
+            n_obs,
+            n_names,
+            True,
+            False,
+            f"Std_TS ⊥ ω (R²={r2:.2f}): per-name signal vol ~constant",
+        )
+    return _result(
+        default_case,
+        r2,
+        t_stat,
+        slope,
+        n_obs,
+        n_names,
+        True,
+        True,
+        f"ambiguous (R²={r2:.2f}, t={t_stat:.1f}); defaulting to Case {default_case} "
+        f"({'price-derived' if price_derived else 'other'})",
+    )
+
+
+def level_shrink_factor(ic: float, t_eff: float) -> float:
+    """IC-uncertainty level shrink: ``1/(1 + 1/(T_eff·IC²)) = g/(g+1)``, ``g=T_eff·IC²``.
+
+    The IC that scales alphas is itself estimated, and its sampling error dominates the
+    mapping (``Var{Δβ/β} ≈ 1/(IC²·T)``). This Bayes-with-zero-prior factor
+    shrinks the alpha **level** toward zero for that estimation error: ``→ 1`` as
+    ``T_eff·IC² → ∞`` (skill well established), ``→ 0`` as ``IC → 0`` or ``T_eff → 0``.
+    ``T_eff`` must be *effective independent* observations (overlapping horizons inflate
+    a raw row count — see :func:`src.alphas.horizon.effective_sample_size`). Anchors:
+    ``IC=0.05, T=60 → 0.13``; ``IC=0.10, T=120 → 0.55``.
+    """
+    g = t_eff * ic * ic
+    return float(g / (g + 1.0)) if np.isfinite(g) and g > 0 else 0.0
 
 
 def cap(alpha: pd.Series, n_std: float = 3.0) -> pd.Series:

--- a/src/analytics/information.py
+++ b/src/analytics/information.py
@@ -12,7 +12,7 @@ layer. Research-clock only.
 """
 
 import math
-from typing import Dict, Sequence
+from typing import Dict, List, Sequence
 
 import numpy as np
 import pandas as pd
@@ -90,3 +90,108 @@ def multiple_testing_inflation(n_trials: int) -> float:
     With 20 informationless strategies this is ~0.64, not 0.05.
     """
     return float(1.0 - 0.95 ** max(n_trials, 0))
+
+
+def risk_bucket_diagnostic(
+    active_weights: pd.Series,
+    sigma: np.ndarray,
+    symbols: Sequence[str],
+    residual_vol: pd.Series,
+    *,
+    min_per_bucket: int = 8,
+) -> Dict:
+    """Equal-risk-contribution check by residual-vol bucket.
+
+    Under **correct** alpha scaling every name contributes ~equally to active variance
+    (``E{z²}=1``), so a residual-vol bucket's share of ``w_aᵀΣw_a`` should track its
+    share of *names*, not its vol. A monotone gradient across vol buckets is the
+    fingerprint of mis-scaled alphas — most often a Case mis-choice (see
+    :func:`src.alphas.refine.case_test`): scaling a Case-2 signal as Case 1 multiplies
+    in ``ω_n`` a second time and tilts variance into the high-vol bucket.
+
+    Buckets names by residual-vol quantile and reports each bucket's share of active
+    variance and of ``Σ|w_a|``, the expected (name-fraction) share, and the per-bucket
+    sampling error ``√(2/n)`` of mean ``z²``. Degrades quintiles → terciles → suppressed
+    as the universe thins (tiny buckets are noise, not signal). ``active_weights`` are
+    the book's active weights ``w_a = w − w_B``; ``sigma`` the annualized Σ over
+    ``symbols`` in that order.
+    """
+    aligned = (
+        pd.concat([active_weights.rename("w"), residual_vol.rename("vol")], axis=1)
+        .reindex(list(symbols))
+        .dropna()
+    )
+    n = len(aligned)
+
+    # Bucket count: a bucket mean of z² has sampling error ≈ √(2/n_bucket); below
+    # ~min_per_bucket names per bucket the gradient is noise, so widen or suppress.
+    if n >= 5 * min_per_bucket:
+        n_buckets = 5
+    elif n >= 3 * max(min_per_bucket - 3, 4):
+        n_buckets = 3
+    else:
+        return {
+            "engaged": False,
+            "n_names": int(n),
+            "reason": f"universe too thin for reliable buckets (n={n}); "
+            f"need ≥ {3 * max(min_per_bucket - 3, 4)} names for terciles",
+        }
+
+    idx = list(aligned.index)
+    w = aligned["w"].to_numpy()
+    vols = aligned["vol"].to_numpy()
+    pos = {s: i for i, s in enumerate(symbols)}
+    order = [pos[s] for s in idx]
+    sub = np.asarray(sigma, dtype=float)[np.ix_(order, order)]
+
+    # Per-name contribution to active variance: w_i·(Σw)_i sums to w_aᵀΣw_a exactly.
+    contrib = w * (sub @ w)
+    total_var = float(contrib.sum())
+    total_abs_w = float(np.abs(w).sum())
+
+    order_by_vol = np.argsort(vols, kind="stable")
+    buckets = np.array_split(order_by_vol, n_buckets)
+    rows: List[Dict] = []
+    var_shares: List[float] = []
+    for b, members in enumerate(buckets):
+        nb = len(members)
+        var_share = float(contrib[members].sum() / total_var) if total_var != 0 else 0.0
+        rows.append(
+            {
+                "bucket": b + 1,  # 1 = lowest residual vol
+                "n_names": int(nb),
+                "vol_low": float(vols[members].min()),
+                "vol_high": float(vols[members].max()),
+                "variance_share": var_share,
+                "name_fraction": float(nb / n),
+                "abs_weight_share": float(np.abs(w[members]).sum() / total_abs_w) if total_abs_w > 0 else 0.0,
+                "sampling_error": float(math.sqrt(2.0 / nb)) if nb > 0 else float("inf"),
+            }
+        )
+        var_shares.append(var_share)
+
+    # Monotone gradient beyond the sampling band ⇒ a vol tilt (mis-scaling).
+    diffs = np.diff(var_shares)
+    monotone = bool(np.all(diffs > 0) or np.all(diffs < 0))
+    gradient = float(var_shares[-1] - var_shares[0])
+    band = float(math.sqrt(2.0 / (n / n_buckets)) / n_buckets)
+    tilt = bool(monotone and abs(gradient) > band)
+    direction = "high-vol" if gradient > 0 else "low-vol"
+
+    return {
+        "engaged": True,
+        "n_names": int(n),
+        "n_buckets": n_buckets,
+        "buckets": rows,
+        "expected_share": float(1.0 / n_buckets),
+        "variance_share_gradient": gradient,
+        "monotone": monotone,
+        "sampling_band": band,
+        "tilt_detected": tilt,
+        "verdict": (
+            f"vol-bucket tilt toward {direction} names (gradient {gradient:+.2f} vs band "
+            f"±{band:.2f}) — likely a Case mis-choice; check the per-signal case_test"
+            if tilt
+            else "no material vol-bucket tilt (contributions ~equal across buckets)"
+        ),
+    }

--- a/src/costs/base.py
+++ b/src/costs/base.py
@@ -69,7 +69,8 @@ class CostModel(ABC):
         """Linear (size-independent) one-way cost per unit of traded notional.
 
         The size-independent part of a trade's cost — the optimizer's L1 turnover
-        coefficient (Spec 016). A model with no linear cost returns 0 (the default);
+        coefficient (the cost-aware objective). A model with no linear cost returns 0
+        (the default);
         :class:`~src.costs.parametric.ParametricCostModel` returns commission + s/2.
         """
         return 0.0
@@ -78,7 +79,8 @@ class CostModel(ABC):
         """√-impact coefficient ``k`` for the optimizer's ``Σ kᵢ·|Δwᵢ|^{3/2}`` term.
 
         The realistic square-root impact is convex in size but not quadratic, so it
-        enters Spec 008's objective as a conic term rather than the risk quadratic.
+        enters the portfolio optimizer's objective as a conic term rather than the
+        risk quadratic.
         ``k`` is *per unit of capital, per rebalance*: the impact cost as a fraction of
         capital of trading ``|Δwᵢ|`` (a fraction of the ``capital`` book) is
         ``k·|Δwᵢ|^{3/2}``. A model with no impact returns 0 (the default).

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -11,7 +11,7 @@ from src.data.panel import FeaturePanel
 from src.data.scan import BarSource, ClientBarSource, slice_to_as_of
 from src.data.store import BAR_COLUMNS, ParquetBarStore
 
-# Lazy out-of-core compute (spec 015) lives in src.data.compute / src.data.edges and
+# Lazy out-of-core compute lives in src.data.compute / src.data.edges and
 # is imported on demand — both need the optional ``store`` extra (polars/duckdb), so
 # they are intentionally not pulled into the base-install import path here.
 

--- a/src/data/compute.py
+++ b/src/data/compute.py
@@ -1,7 +1,7 @@
-"""Lazy, out-of-core compute over the bar panel (spec 015 — Polars · DuckDB).
+"""Lazy, out-of-core compute over the bar panel (Polars · DuckDB).
 
-Spec 011 delivered the *storage* half of out-of-core (a Parquet/Arrow ``BarSource``
-behind ``scan()``). This module is the *compute* half: the hot, panel-wide
+The *storage* half of out-of-core (a Parquet/Arrow ``BarSource`` behind ``scan()``)
+lives in the store module. This module is the *compute* half: the hot, panel-wide
 operations expressed as a **lazy** plan, rather than eagerly materializing a ``T×N``
 pandas panel into RAM.
 

--- a/src/data/edges.py
+++ b/src/data/edges.py
@@ -1,7 +1,7 @@
 """The pandas edge — the *only* sanctioned crossings between the lazy columnar core
 and pandas.
 
-The lazy compute model (spec 015) keeps the panel in Arrow/Polars and never
+The lazy compute model keeps the panel in Arrow/Polars and never
 materializes the whole thing into pandas. But pandas is still the right currency at
 two narrow places: a **per-symbol leaf** where the data is provably small (the
 indicator math the strategy already speaks), and the **final report** a human reads.

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -285,16 +285,19 @@ def build_server(data_client=None):
         benchmark: str = "SPY",
         neutralize: bool = False,
         lookback_days: int = 180,
+        scaling: str = "case1",
     ) -> Dict[str, Any]:
         """Rank `symbols` by continuous alpha (residual-return forecast) as of a date.
 
         Turns each name's view into a comparable, annualized residual-return
-        forecast via alpha = sigma * IC * z (cross-sectional z-score scaled by
-        residual vol and an ASSUMED IC). source: "strategy" uses the strategy's
-        continuous conviction; "signal" uses its BUY/SELL/HOLD as +1/-1/0; "scanner"
-        uses the scanner's continuous strength. Read-only: forecasts only, never
-        reads a forward return, places no orders. The absolute scale is only as good
-        as the assumed IC; relative ranking is not.
+        forecast. `scaling` picks the per-name scaling: "case1" =
+        sigma*IC*z (the default; correct when per-name signal vol is constant across
+        names), "case2" = IC*c_g*z (no per-name vol multiply, for signals whose vol is
+        proportional to the name's vol — most price signals), or "auto" to let a
+        Std_TS-vs-omega regression decide (echoed under `case`). source: "strategy"
+        uses the strategy's continuous conviction; "signal" uses its BUY/SELL/HOLD as
+        +1/-1/0; "scanner" uses the scanner's continuous strength. Read-only. The
+        absolute scale is only as good as the assumed IC; relative ranking is not.
         """
         inputs = {
             "strategy": strategy,
@@ -305,6 +308,7 @@ def build_server(data_client=None):
             "ic": ic,
             "benchmark": benchmark,
             "neutralize": neutralize,
+            "scaling": scaling,
         }
         result = analysis.compute_alphas(
             dc,
@@ -317,6 +321,7 @@ def build_server(data_client=None):
             benchmark=benchmark,
             neutralize=neutralize,
             lookback_days=lookback_days,
+            scaling=scaling,
         )
         return _logged("compute_alphas", inputs, result)
 
@@ -461,7 +466,7 @@ def build_server(data_client=None):
         horizon: int = 5,
         n_trials: int = 1,
     ) -> Dict[str, Any]:
-        """Measure a strategy's IC, breadth, and predicted-vs-realized IR (spec 009).
+        """Measure a strategy's IC, breadth, and predicted-vs-realized IR.
 
         Pairs the alpha known at each rebalance with the subsequent realized residual
         return (strict forward alignment) to measure the information coefficient

--- a/src/portfolio/optimizer.py
+++ b/src/portfolio/optimizer.py
@@ -4,8 +4,8 @@ The OR-Tools :class:`~src.portfolio.allocator.PortfolioAllocator` maximizes a sc
 score subject to constraints - it has no notion of risk, so it piles weight onto the
 highest-scoring names regardless of how correlated they are. Active-management
 construction instead maximizes a **risk-adjusted utility**, trading expected residual
-return (alpha, Spec 005) against active risk (covariance, Spec 006) - and, once cost is
-in the objective (Spec 016), against the *name-specific* cost of getting there:
+return (alpha) against active risk (covariance) - and, once cost is in the objective
+(the cost-aware solve), against the *name-specific* cost of getting there:
 
     U(w) = αᵀw − λ_A · wᵀΣw − Σᵢ cᵢ·|Δwᵢ| − Σᵢ kᵢ·|Δwᵢ|^{3/2}      (Δw = w − w₀)
            └ value ┘  └ active risk ┘  └ linear turnover ┘  └ √-impact (conic) ┘
@@ -26,7 +26,7 @@ budget dual, and each coordinate has a closed form (a soft-threshold *around w�
 linear cost; a quadratic-in-√ root for the √-impact) - so the whole conic problem is
 solved by the same 1-D budget bisection the cost-free projection already used, with no
 external solver. When ``cᵢ = kᵢ = 0`` it reduces *exactly* to the cost-free projected
-gradient, so Spec 008's behavior is unchanged.
+gradient, so the cost-blind behavior is unchanged.
 """
 
 from dataclasses import dataclass, field
@@ -43,7 +43,7 @@ from src.risk.base import RiskMatrix
 class CostInputs:
     """Per-name, as-of liquidity context the cost model prices trades against.
 
-    Threaded from Spec 007: a fractional ``spread`` (quoted, or a high-low-range proxy),
+    Threaded from the cost model: a fractional ``spread`` (quoted, or a high-low-range proxy),
     trailing ``adv_dollar`` (ADV in dollars = price · share-ADV), and trailing
     ``daily_vol`` (daily return volatility). All keyed by symbol; missing names fall
     back to the cost model's defaults (spread) or drop the √-impact term (ADV/vol).
@@ -113,8 +113,8 @@ class MeanVarianceOptimizer:
         016): the objective gains a name-specific linear turnover penalty and, when
         ``capital`` is given, the √-impact term. Cost coefficients are *annualized* to
         the same units as the (annualized) alpha by dividing the one-way rate by
-        ``holding_period_years`` - matching Spec 007's alpha-haircut and the ex-post
-        cost drag. Without a cost model the solve is cost-blind (Spec 008, unchanged).
+        ``holding_period_years`` - matching the cost model's alpha-haircut and the
+        ex-post cost drag. Without a cost model the solve is cost-blind (unchanged).
 
         Returns the weights, the diagnostics (``IR*``, predicted TE/IR, transfer
         coefficient, value added, turnover, and - when cost-aware - the linear/impact
@@ -145,7 +145,7 @@ class MeanVarianceOptimizer:
 
         w0 = self._vector(current_weights or {}, symbols)
         # Per-name cost coefficients (annualized), aligned to `symbols`. Both zero when
-        # cost-blind -> the solve reduces exactly to Spec 008's projected gradient.
+        # cost-blind -> the solve reduces exactly to the cost-blind projected gradient.
         c_lin, k_imp = self._cost_coefficients(
             cost_model, cost_inputs, capital, holding_period_years, symbols
         )
@@ -356,7 +356,7 @@ class MeanVarianceOptimizer:
             linear_cost = float(np.sum(c_lin * np.abs(dw)))
             impact_cost = float(np.sum(k_imp * np.abs(dw) ** 1.5))
             rebalance_cost = linear_cost + impact_cost
-            # Round-trip haircut on the *held book* (007 §3.2 / the capacity convention):
+            # Round-trip haircut on the *held book* (the capacity convention):
             # entering AND exiting each position, amortized over the holding period. This
             # is the conservative headline net figure - the same cost model _capacity
             # prices, so the net return and the capacity number agree.

--- a/src/risk/factor.py
+++ b/src/risk/factor.py
@@ -4,7 +4,7 @@ A factor model is the preferred form for active risk: the parameter count drops 
 ``O(N²)`` to ``O(N·K)``, Σ is invertible and stable by construction (``K`` small), and
 — crucially — risk becomes **attributable**, splitting into *factor* risk
 (``w_aᵀ X F Xᵀ w_a``) and *specific* risk (``w_aᵀ Δ w_a``). That decomposition is what
-Spec 009's attribution and Spec 005's factor-neutralization both consume.
+the information-analysis attribution and the alpha factor-neutralization both consume.
 
 Factor returns ``f_t`` are recovered each period by a cross-sectional regression of
 that period's returns on the (slowly-varying) exposures ``X``; ``F`` is their

--- a/src/risk/streaming.py
+++ b/src/risk/streaming.py
@@ -6,7 +6,7 @@ materialization in the stack: it builds an aligned returns DataFrame for the who
 history and hands it to an estimator. For a broad universe over many years that ``T×N``
 panel is the thing that does not fit in RAM.
 
-This module is the out-of-core counterpart (spec 015): it estimates the *same*
+This module is the out-of-core counterpart: it estimates the *same*
 quantities by **streaming** the return panel out of a
 :class:`~src.data.store.ParquetBarStore` in date-chunks and accumulating sufficient
 statistics. It never holds the ``T×N`` panel: peak working memory is one chunk

--- a/src/services/analysis.py
+++ b/src/services/analysis.py
@@ -352,17 +352,26 @@ def compute_alphas(
     neutralize_factors: Sequence[str] = (),
     lookback_days: int = 180,
     timeframe: Optional[str] = None,
+    scaling: str = "case1",
+    price_derived: bool = True,
 ) -> Dict[str, Any]:
     """Turn a per-name view into ranked residual-return alphas, via a feature panel.
 
     Read-only research-clock flow: scans the universe as of ``as_of`` (leakage-safe),
     assembles a :class:`FeaturePanel` (risk + score columns), refines it into a
-    comparable annualized forecast (``alpha = sigma * IC * z``), and returns the
-    ranked table. Produces no orders and saves no config.
+    comparable annualized forecast, and returns the ranked table. Produces no orders
+    and saves no config.
 
     ``source`` selects the score column's origin: ``"strategy"`` uses the strategy's
     continuous conviction; ``"signal"`` uses its discrete BUY/SELL/HOLD as +1/-1/0;
     ``"scanner"`` uses the ``scanner``'s continuous signed strength.
+
+    ``scaling`` picks the per-name scaling: ``"case1"`` = ``ω·IC·z`` (the default),
+    ``"case2"`` = ``IC·c_g·z`` (no per-name vol multiply), or ``"auto"`` to let
+    :func:`~src.alphas.refine.case_test` decide from trailing history
+    (``price_derived`` is the base-rate default when the test can't decide). The case
+    diagnostics — chosen case, R², both candidates' cross-sectional correlation — are
+    echoed under ``case`` whenever the test runs so a wrong call is visible.
     """
     run_id = new_run_id()
     strat = _strategy(strategy, None)
@@ -389,7 +398,20 @@ def compute_alphas(
         add_factor_exposure_features(panel, universe_bars, bench_frame, neutralize_factors)
     add_score_feature(panel, scorer(), universe_bars)
 
-    context = AlphaContext(ic=ic, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors))
+    # Case selection: only when the caller asks — the "case1" default keeps the base
+    # refinement pipeline byte-for-byte (the equivalence guard) and cheap.
+    case_diag = None
+    chosen_scaling = scaling
+    if scaling in ("auto", "case2") and panel.has("residual_vol"):
+        case_diag = _run_case_test(universe_bars, scorer(), panel.get("residual_vol"), price_derived)
+        chosen_scaling = f"case{case_diag['case']}" if scaling == "auto" else "case2"
+
+    context = AlphaContext(
+        ic=ic,
+        neutralize=neutralize,
+        neutralize_factors=tuple(neutralize_factors),
+        scaling=chosen_scaling,
+    )
     refine_alpha(panel, context)
     alphas = panel_to_alphas(panel, context)
 
@@ -420,10 +442,15 @@ def compute_alphas(
         "neutralized_against": list(panel.meta.get("neutralized_against", [])),
         "universe_size": int(panel.get("score").notna().sum()) if panel.has("score") else 0,
         "low_confidence": bool(panel.meta.get("low_confidence")),
+        "scaling": chosen_scaling,
+        "case": _jsonable(case_diag) if case_diag else None,
+        "shrink_chain": _jsonable(panel.meta.get("shrink_chain", [])),
         "alphas": _jsonable(table),
         "note": "Alphas are residual-return FORECASTS, annualized, scaled by an "
         "ASSUMED IC (a prior until it is measured from realized outcomes). Relative sizing across "
-        "names is correct regardless of IC; the absolute scale is only as good as it.",
+        "names is correct regardless of IC; the absolute scale is only as good as it. "
+        "'case' picks Case-1 (ω·IC·z) vs Case-2 (IC·c_g·z) scaling; the IC-uncertainty "
+        "level shrink engages only where a MEASURED IC is available (compute_information).",
     }
 
 
@@ -446,8 +473,8 @@ def compute_combined_alphas(
     correlation matrix over a trailing window (realized residual returns), shrinks the
     ICs by their estimation confidence, and combines them with GLS weights
     (``Ω⁻¹·IC``) so redundant signals split a weight rather than double-count. The
-    combined score is scaled by the **measured** combined IC - replacing Spec 005's
-    assumed per-signal scalar, never applied twice. Returns the ranked alpha table
+    combined score is scaled by the **measured** combined IC - replacing the
+    single-signal assumed scalar, never applied twice. Returns the ranked alpha table
     plus the measured ICs, weights, and correlation matrix.
     """
     from src.alphas import combined_score, measure_signals, strategy_scorer
@@ -517,9 +544,30 @@ def compute_combined_alphas(
         "signal_weights": _jsonable(measurement.weights),
         "signal_correlation": _jsonable(measurement.correlation.to_dict()),
         "alphas": _jsonable(table),
+        # Shrink-chain audit: the "is the IC real" level shrink is OWNED HERE by the
+        # combination's per-signal Bayesian shrink (the same g/(g+1) math as the
+        # single-signal level shrink, T = n_periods), so it is NOT re-applied
+        # post-combination — that would double-shrink and undertrade forever. The
+        # combination owns credit-sharing (Ω⁻¹) AND, on this path, the level; the
+        # single-signal level shrink owns it on the non-combined path. See the
+        # Multi-signal and Continuous-alphas pages in the engineering docs.
+        "shrink_chain": _jsonable(
+            [
+                {"step": "measure", "ics": measurement.ics},
+                {
+                    "step": "ic_uncertainty",
+                    "owner": "combination_shrink",
+                    "shrunk_ics": measurement.shrunk_ics,
+                    "n_periods": measurement.n_periods,
+                },
+                {"step": "combine", "combined_ic": measurement.combined_ic},
+            ]
+        ),
         "note": "ICs and the signal correlation are MEASURED over the trailing window "
         "(not assumed) and shrunk by estimation confidence; redundant signals split a "
-        "weight via Ω⁻¹. Measure on out-of-sample data for an honest combination.",
+        "weight via Ω⁻¹. The IC-uncertainty level shrink is owned here by the per-signal "
+        "Bayesian shrink (not re-applied — that would double-shrink). Measure on "
+        "out-of-sample data for an honest combination.",
     }
 
 
@@ -543,7 +591,8 @@ def compute_information(
 ) -> Dict[str, Any]:
     """Measure a strategy's information coefficient, breadth, and information ratio.
 
-    Read-only research-clock diagnostic (spec 009). At sampled rebalances it pairs the
+    Read-only research-clock diagnostic (see the Information-analysis page in the
+    engineering docs). At sampled rebalances it pairs the
     alpha forecast known *at* ``t`` with the realized **residual** return over
     ``(t, t+horizon]`` (strict forward alignment - rewarding skill, not beta), giving
     the IC time series (Pearson + rank), its t-stat, the effective breadth ``BR_eff``
@@ -554,6 +603,8 @@ def compute_information(
     (``compute_risk(..., model='factor')``); realized-return attribution and capacity
     are smaller follow-ons.
     """
+    from src.alphas import horizon as hz
+    from src.alphas import refine
     from src.analytics import information as info
     from src.indicators import indicators
 
@@ -589,6 +640,7 @@ def compute_information(
     pearson_ics, rank_ics, portfolio_returns = [], [], []
     factor_contribs, specific_contribs = [], []
     n_names_seen = []
+    last_weights = None  # the most recent paper active book, for the bucket diagnostic
     for j in points:
         t, t_fwd = window[j], window[j + horizon]
         alpha = _alpha_cross_section(universe_bars, bench, scorer, periods_per_year, t, ctx)
@@ -603,6 +655,7 @@ def compute_information(
         z = aligned["alpha"] - aligned["alpha"].mean()
         if z.std() > 0:
             w = z / z.std()
+            last_weights = w  # mean-zero ⇒ already an active book
             portfolio_returns.append(float(w @ aligned["resid"]))
             # Attribution: split that return into factor vs specific by projecting the
             # realized cross-section onto the factor exposures (the split closes exactly).
@@ -626,6 +679,32 @@ def compute_information(
 
     breadth = info.effective_breadth(n_names, rebalances_per_year, rho_bar)
     pred_ir = info.predicted_ir(stats["mean_ic"], breadth["br_eff"])
+
+    # IC-uncertainty level shrink: how much of the measured-IC level survives its own
+    # estimation error. T_eff deflates the rebalance count by the horizon/spacing overlap
+    # (raw count under-shrinks); this is the honest haircut a human applies to the
+    # recommended_ic before feeding it back into the alpha scaling.
+    spacing = float(np.mean(np.diff(points))) if len(points) > 1 else float(horizon)
+    t_eff = hz.effective_sample_size(stats["periods"], horizon, spacing)
+    shrink_factor = refine.level_shrink_factor(stats["mean_ic"], t_eff)
+    shrink_chain = [
+        {"step": "scale", "note": "ω·IC·z at the recommended (measured) IC"},
+        {
+            "step": "ic_uncertainty",
+            "owner": "level_shrink",
+            "ic": stats["mean_ic"],
+            "t_eff": t_eff,
+            "multiplier": shrink_factor,
+        },
+    ]
+
+    # Equal-risk-contribution diagnostic: does the current paper book spread active
+    # variance evenly across residual-vol buckets, or tilt into one?
+    bucket_diag = None
+    if matrix is not None and last_weights is not None and len(matrix.symbols) > 1:
+        bucket_diag = info.risk_bucket_diagnostic(
+            last_weights, matrix.sigma, matrix.symbols, matrix.volatilities()
+        )
 
     realized_ir = 0.0
     if len(portfolio_returns) > 1 and np.std(portfolio_returns) > 0:
@@ -658,6 +737,10 @@ def compute_information(
         "n_trials": n_trials,
         "sanity_ceiling_breached": abs(realized_ir) > 2.0,
         "recommended_ic": stats["mean_ic"],  # feeds back into 005's scaling — a human applies it
+        "effective_t": t_eff,
+        "level_shrink_factor": shrink_factor,  # keep this fraction of the naive alpha level
+        "shrink_chain": _jsonable(shrink_chain),
+        "risk_bucket_diagnostic": _jsonable(bucket_diag) if bucket_diag else None,
         # Attribution: the realized active return split into factor tilts vs genuine
         # name selection (they sum to the realized portfolio return per rebalance).
         "factor_return": float(np.mean(factor_contribs)) if factor_contribs else 0.0,
@@ -667,8 +750,123 @@ def compute_information(
         "by ρ̄. An IC t-stat < 2, a realized IR within its standard-error band of 0, or "
         "a realized IR > 2 on public data all mean: not skill yet. factor_return vs "
         "specific_return attributes the realized active return; capacity is in the "
-        "portfolio report.",
+        "portfolio report. level_shrink_factor is the IC-uncertainty haircut on the "
+        "recommended_ic LEVEL for its own estimation error (T_eff deflates for horizon "
+        "overlap); risk_bucket_diagnostic flags a residual-vol tilt from mis-scaling.",
     }
+
+
+def run_scaling_ab(
+    data_client: MarketDataClient,
+    strategy: str,
+    symbols: List[str],
+    start: datetime,
+    end: datetime,
+    source: str = "strategy",
+    scanner: str = "volume",
+    benchmark: str = "SPY",
+    neutralize: bool = True,
+    neutralize_factors: Sequence[str] = (),
+    ic_prior: float = DEFAULT_IC,
+    horizon: int = 5,
+    n_points: int = 24,
+    timeframe: str = "1Day",
+    price_derived: bool = True,
+) -> Dict[str, Any]:
+    """A/B the two scalings walk-forward: realized IR under Case 1 vs Case 2.
+
+    The regression-based :func:`~src.alphas.refine.case_test` is one cheap number; this
+    is the ground-truth tiebreak. At each rebalance it builds
+    the paper alpha book under **both** scalings (same z, same measured residual return;
+    only the per-name vol multiply differs) and reports each book's realized information
+    ratio, alongside the regression's recommendation. When the two disagree, trust the
+    A/B — but note the IR standard-error band before acting on a small gap.
+    """
+    run_id = new_run_id()
+    strat = _strategy(strategy, None)
+    periods_per_year = Timeframe.parse(timeframe).periods_per_year()
+    rebalances_per_year = periods_per_year / horizon
+
+    bars = ClientBarSource(data_client).scan([*symbols, benchmark], timeframe, end, _window_days(start, end))
+    bench = bars.get(benchmark)
+    universe_bars = {sym: bars[sym] for sym in symbols if sym in bars}
+    if bench is None or bench.empty or not universe_bars:
+        return {
+            "run_id": run_id,
+            "strategy": strategy,
+            "periods": 0,
+            "note": "Insufficient data: need a benchmark series and scored names.",
+        }
+
+    scorer = {
+        "strategy": lambda: strategy_scorer(strat),
+        "signal": lambda: signal_scorer(strat),
+        "scanner": lambda: scanner_scorer(_scanner(scanner)),
+    }[source]()
+    ctxs = {
+        kind: AlphaContext(
+            ic=ic_prior, neutralize=neutralize, neutralize_factors=tuple(neutralize_factors), scaling=kind
+        )
+        for kind in ("case1", "case2")
+    }
+
+    index = bench.index
+    window = index[(index >= _to_ts(start, index)) & (index <= _to_ts(end, index))]
+    points = _rebalance_points(len(window), horizon, n_points)
+
+    returns: Dict[str, List[float]] = {"case1": [], "case2": []}
+    for j in points:
+        t, t_fwd = window[j], window[j + horizon]
+        resid = _forward_residual_return(universe_bars, bench, t, t_fwd, indicators=_indicators())
+        if resid.dropna().empty:
+            continue
+        for kind, ctx in ctxs.items():
+            alpha = _alpha_cross_section(universe_bars, bench, scorer, periods_per_year, t, ctx)
+            aligned = pd.concat([alpha, resid], axis=1, keys=["a", "r"]).dropna()
+            if len(aligned) < 5:
+                continue
+            z = aligned["a"] - aligned["a"].mean()
+            if z.std() > 0:
+                returns[kind].append(float((z / z.std()) @ aligned["r"]))
+
+    def _ir(r: List[float]) -> float:
+        if len(r) > 1 and np.std(r) > 0:
+            return float(np.mean(r) / np.std(r) * np.sqrt(rebalances_per_year))
+        return 0.0
+
+    case1_ir, case2_ir = _ir(returns["case1"]), _ir(returns["case2"])
+
+    # Regression recommendation needs the per-name residual vol as of the window end.
+    panel = FeaturePanel.for_universe(end, list(universe_bars))
+    add_risk_features(panel, universe_bars, bench, periods_per_year)
+    resid_vol = panel.get("residual_vol") if panel.has("residual_vol") else pd.Series(dtype=float)
+    case_diag = _run_case_test(universe_bars, scorer, resid_vol, price_derived)
+
+    ab_pick = "case2" if case2_ir > case1_ir else "case1"
+    return {
+        "run_id": run_id,
+        "strategy": strategy,
+        "source": source,
+        "window": {"start": start.isoformat(), "end": end.isoformat()},
+        "horizon_bars": horizon,
+        "periods": min(len(returns["case1"]), len(returns["case2"])),
+        "case1_realized_ir": case1_ir,
+        "case2_realized_ir": case2_ir,
+        "regression_pick": f"case{case_diag['case']}",
+        "ab_pick": ab_pick,
+        "agree": bool(f"case{case_diag['case']}" == ab_pick),
+        "case_test": _jsonable(case_diag),
+        "note": "case1 = ω·IC·z, case2 = IC·c_g·z. A/B realized IR is the ground truth; "
+        "the regression case_test is the cheap proxy. Compare the IR gap to its "
+        "standard-error band before acting — a small gap is noise.",
+    }
+
+
+def _indicators():
+    """The indicators module (deferred import to keep the module load light)."""
+    from src.indicators import indicators
+
+    return indicators
 
 
 def compute_horizon(
@@ -689,7 +887,8 @@ def compute_horizon(
 ) -> Dict[str, Any]:
     """Measure an alpha's decay and recommend a rebalance cadence + lagged blend.
 
-    Read-only research diagnostic (spec 012): measures the IC-vs-lag profile (the
+    Read-only research diagnostic (see the Information-horizon page in the engineering
+    docs): measures the IC-vs-lag profile (the
     alpha at ``t`` vs the residual return realized ``n`` periods later, for
     ``n = 1..max_lag``), fits the per-period decay ``δ`` and half-life, derives the
     cadence that maximizes ``IC(Δt)·√(1/Δt)``, and computes the IR-maximizing
@@ -907,7 +1106,7 @@ def construct_portfolio(
     ``αᵀw − λ·wᵀΣw − cost(w − w₀)`` over long-only, box-bounded, budgeted (and
     optionally cardinality-capped) weights, calibrating ``λ`` to ``target_te``.
 
-    With ``cost_aware`` (default) the objective carries 007's cost (Spec 016):
+    With ``cost_aware`` (default) the objective carries the transaction-cost term:
     name-specific linear turnover (commission + a high-low-range spread proxy) and,
     when ``capital`` is set, the √-impact term - so the optimizer trades a name's
     alpha against *that name's* cost and a no-trade band emerges from the cost itself.
@@ -1161,6 +1360,69 @@ def _rebalance_points(n_bars: int, horizon: int, n_points: int):
     if last <= warmup:
         return []
     return np.linspace(warmup, last, num=min(n_points, last - warmup), dtype=int)
+
+
+def _raw_signal_history(universe_bars, scorer, n_points: int = 48, warmup: int = 30) -> pd.DataFrame:
+    """Trailing time×name frame of the **raw** signal, for the Case test.
+
+    Scores every name at ``n_points`` dates along the reference index using only bars
+    ``≤ t`` (the same leakage discipline as the alpha cross-section), so each column is
+    a name's raw-signal time series ``g_n(t)`` — the input :func:`refine.case_test`
+    regresses ``Std_TS`` on ``ω``.
+    """
+    if not universe_bars:
+        return pd.DataFrame()
+    ref = max((f.index for f in universe_bars.values()), key=len)
+    last = len(ref) - 1
+    if last <= warmup:
+        points = range(len(ref))
+    else:
+        points = np.linspace(warmup, last, num=min(n_points, last - warmup), dtype=int)
+
+    rows: Dict[Any, Dict[str, float]] = {}
+    for j in points:
+        t = ref[j]
+        row: Dict[str, float] = {}
+        for sym, frame in universe_bars.items():
+            hist = frame.loc[frame.index <= t]
+            if len(hist) < 2:
+                continue
+            val = scorer(hist)
+            if val is not None and not pd.isna(val):
+                row[sym] = float(val)
+        if row:
+            rows[t] = row
+    return pd.DataFrame(rows).T
+
+
+def _run_case_test(universe_bars, scorer, residual_vol: pd.Series, price_derived: bool) -> Dict[str, Any]:
+    """Case-1/Case-2 decision + the two candidate alphas' cross-sectional correlation.
+
+    Runs :func:`refine.case_test` on the trailing raw-signal history, then reports how
+    different the two scalings actually are at the latest cross-section (``corr`` of the
+    Case-1 ``ω·z`` vector with the Case-2 ``c_g·z`` vector) — a correlation near 1 means
+    the case choice barely matters here, near 0 means it matters a lot.
+    """
+    from src.alphas import refine
+
+    history = _raw_signal_history(universe_bars, scorer)
+    diag = refine.case_test(history, residual_vol, price_derived=price_derived)
+
+    corr = float("nan")
+    c_g = float("nan")
+    if not history.empty:
+        g = history.iloc[-1].dropna()
+        if len(g) >= 2:
+            z = refine.zscore(refine.winsorize(g))
+            vol = residual_vol.reindex(z.index)
+            c_g = refine.case_scale_factor(g, vol)
+            scale = c_g if (c_g == c_g) else float(vol.mean())
+            a1, a2 = vol * z, scale * z  # IC cancels in the correlation
+            if a1.std() > 0 and a2.std() > 0:
+                corr = float(a1.corr(a2))
+    diag["candidate_correlation"] = corr
+    diag["c_g"] = c_g
+    return diag
 
 
 def _alpha_cross_section(universe_bars, bench, scorer, periods_per_year, t, ctx) -> pd.Series:

--- a/tests/test_alphas.py
+++ b/tests/test_alphas.py
@@ -140,7 +140,7 @@ def test_refine_market_factor_supersedes_plain_beta():
 
 def test_refine_names_missing_exposures_are_mean_imputed_not_dropped():
     """A name missing a factor value gets the cross-sectional mean (0), staying in
-    the regression — it must not silently lose beta neutralization (G&K union trap)."""
+    the regression — it must not silently lose beta neutralization (the union trap)."""
     raw = {f"S{i}": float(i % 5) - 2 for i in range(12)}
     betas = {f"S{i}": 1.0 + 0.1 * i for i in range(12)}
     panel = _panel(raw, betas=betas)

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -1,4 +1,4 @@
-"""Tests for lazy out-of-core compute (spec 015 — Polars · DuckDB).
+"""Tests for lazy out-of-core compute (Polars · DuckDB).
 
 Skipped automatically unless the ``store`` extra (pyarrow + polars + duckdb) is
 installed. These prove the lazy ports are *faithful*: each migrated op is checked
@@ -280,7 +280,7 @@ def test_sql_query_empty_result_has_schema(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Regression tests for the spec-015 adversarial review.
+# Regression tests for the out-of-core adversarial review.
 # Each guards a confirmed finding the original suite missed.
 # --------------------------------------------------------------------------- #
 def _shuffled_store(tmp_path, n=40, seed=3):

--- a/tests/test_cost_aware.py
+++ b/tests/test_cost_aware.py
@@ -1,9 +1,9 @@
-"""Tests for cost-aware portfolio construction (spec 016).
+"""Tests for cost-aware portfolio construction.
 
 Cost is inside the objective: ``αᵀw − λ·wᵀΣw − Σ cᵢ|Δwᵢ| − Σ kᵢ|Δwᵢ|^{3/2}``. These
-tests cover the spec §6 checklist — name-specific tilt, the emergent no-trade band,
-w₀ sensitivity, √-impact super-linearity, the linear↔conic gap, and the zero-cost
-reduction to spec 008 — plus the proximal-operator primitives, a KKT optimality
+tests cover name-specific tilt, the emergent no-trade band, w₀ sensitivity, √-impact
+super-linearity, the linear↔conic gap, and the zero-cost reduction to the cost-blind
+solve — plus the proximal-operator primitives, a KKT optimality
 certificate, the cost-model coefficients, and the end-to-end service integration.
 
 Offline and deterministic.
@@ -53,7 +53,7 @@ def _inputs(spread, adv_dollar=1e12, daily_vol=0.02) -> CostInputs:
     )
 
 
-# --- closed-form / zero-cost reduction (spec §6 "closed-form sanity") --------
+# --- closed-form / zero-cost reduction ---------------------------------------
 def test_zero_cost_reduces_to_cost_blind_solve():
     free = ParametricCostModel(commission_bps=0.0, default_spread_bps=0.0)
     blind = MeanVarianceOptimizer(max_weight=0.5).optimize(_alphas(), _risk(), risk_aversion=LAM)
@@ -66,13 +66,13 @@ def test_zero_cost_reduces_to_cost_blind_solve():
         holding_period_years=H,
     )
     assert np.allclose(_vec(zero), _vec(blind), atol=1e-9)
-    # Unconstrained optimum still the spec-008 closed form, untouched by the (zero) cost.
+    # Unconstrained optimum still the cost-blind closed form, untouched by the (zero) cost.
     expected = (np.linalg.inv(SIGMA) @ ALPHA) / (2 * LAM)
     got = np.array([blind.unconstrained_weights[s] for s in SYMS])
     assert np.allclose(got, expected)
 
 
-# --- name-specific cost changes weights (spec §6 test 1) ---------------------
+# --- name-specific cost changes weights --------------------------------------
 def test_uniform_cost_from_cash_is_a_noop():
     # Long-only from cash with a uniform per-name cost: Σcᵢ|wᵢ| = c·Σwᵢ = c is constant,
     # so the optimum is unchanged — the baseline the name-specific case must beat.
@@ -106,7 +106,7 @@ def test_name_specific_cost_tilts_away_from_expensive_names():
     assert abs(sum(tilted.weights.values()) - 1.0) < 1e-6  # still fully invested
 
 
-# --- emergent no-trade band (spec §6 test 2) ---------------------------------
+# --- emergent no-trade band --------------------------------------------------
 def test_emergent_no_trade_band_suppresses_subthreshold_churn():
     model = ParametricCostModel()
     opt = MeanVarianceOptimizer(max_weight=0.5)  # no_trade_band=0: the band must EMERGE from cost
@@ -150,7 +150,7 @@ def test_no_trade_band_half_width_is_the_one_way_cost():
     assert 2 * c_one_way == pytest.approx(model.annual_cost_rate(tiny, H), rel=1e-6)
 
 
-# --- w0 sensitivity (spec §6 test 3) -----------------------------------------
+# --- w0 sensitivity ----------------------------------------------------------
 def test_turnover_depends_on_current_weights():
     model = ParametricCostModel()
     opt = MeanVarianceOptimizer(max_weight=0.5)
@@ -162,7 +162,7 @@ def test_turnover_depends_on_current_weights():
     assert from_cash.diagnostics["turnover"] > 0.5  # from cash → fully invest
 
 
-# --- √-impact super-linearity (spec §6 test 4) -------------------------------
+# --- √-impact super-linearity ------------------------------------------------
 def test_impact_penalty_is_superlinear_in_trade_size():
     # The penalty kᵢ·|Δw|^{3/2} under the optimizer's *own* coefficient: doubling the
     # trade more than doubles it (×2^1.5). Uses the real _cost_coefficients so an
@@ -198,7 +198,7 @@ def test_sqrt_impact_spreads_size_away_from_illiquid_names():
     assert abs(sum(conic.weights.values()) - 1.0) < 1e-6
 
 
-# --- linear ↔ conic gap (spec §6 test 5) -------------------------------------
+# --- linear ↔ conic gap ------------------------------------------------------
 def test_linear_and_conic_agree_when_impact_is_negligible_and_gap_is_reported():
     model = ParametricCostModel()
     ci = _inputs(0.0005, adv_dollar=1e13)  # very deep books
@@ -419,7 +419,7 @@ def test_round_trip_headline_is_conservative_and_capacity_aligned():
     assert d["expected_active_return_net"] == pytest.approx(d["expected_active_return"] - expected_rt)
 
 
-# --- cardinality / dust re-solve with cost (spec §4 factor 6 interaction) ----
+# --- cardinality / dust re-solve with cost -----------------------------------
 def test_cardinality_liquidation_cost_is_counted():
     # A full-book w₀ with max_names=2 must fully liquidate the dropped names; that
     # liquidation turnover and its cost must appear in the diagnostics (priced over w−w₀).

--- a/tests/test_costs.py
+++ b/tests/test_costs.py
@@ -1,4 +1,4 @@
-"""Tests for the transaction-cost model and its backtest integration (spec 007)."""
+"""Tests for the transaction-cost model and its backtest integration."""
 
 import math
 from datetime import datetime

--- a/tests/test_forecast_refinement_v2.py
+++ b/tests/test_forecast_refinement_v2.py
@@ -1,0 +1,285 @@
+"""Tests for the v2 alpha-forecast refinements.
+
+Covers the three refinements the base refine/combine pipeline skipped:
+  1. the per-signal Case test + Case-2 scaling (``IC·c_g·z`` vs ``ω·IC·z``),
+  2. the IC-uncertainty **level** shrink with an honest effective T, and
+  3. the equal-risk-contribution bucket diagnostic.
+
+Offline and deterministic. The closed-form math is tested directly; the service
+flow is exercised for structure and the Case-1 equivalence guard.
+"""
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+
+from src.alphas import refine
+from src.alphas.base import AlphaContext, refine_alpha
+from src.alphas.horizon import effective_sample_size
+from src.analytics.information import risk_bucket_diagnostic
+from src.data.panel import FeaturePanel
+from src.marketdata.client import MarketDataClient
+from src.services import analysis
+from tests.fakes import DictMarketData, make_ohlcv
+
+AS_OF = datetime(2024, 6, 1)
+
+
+# --------------------------------------------------------------------------- #
+# 1. The Case test
+# --------------------------------------------------------------------------- #
+def _signal_history(std_ts_by_name, n_obs=48, seed=0):
+    """A time×name frame whose per-name time-series std matches ``std_ts_by_name``."""
+    rng = np.random.default_rng(seed)
+    cols = {name: rng.normal(0.0, s, n_obs) for name, s in std_ts_by_name.items()}
+    return pd.DataFrame(cols)
+
+
+def test_case1_signal_detected_when_vol_constant():
+    # Per-name signal vol ~constant across names ⇒ Std_TS ⊥ ω ⇒ Case 1.
+    names = [f"S{i}" for i in range(40)]
+    omega = pd.Series({n: 0.10 + 0.005 * i for i, n in enumerate(names)})
+    # Long history + a wide cross-section so the per-name sample-std noise (which is
+    # uncorrelated with ω, but spuriously fits ~1/(K−1) of the variance) stays well
+    # below the R² floor; the true relation is flat ⇒ Case 1.
+    history = _signal_history({n: 0.30 for n in names}, n_obs=400)  # constant TS vol
+    res = refine.case_test(history, omega, price_derived=True)
+    assert res["case"] == 1
+    assert res["engaged"] and not res["ambiguous"]
+    assert res["r_squared"] <= 0.05
+
+
+def test_case2_signal_detected_when_vol_proportional_to_omega():
+    # Per-name signal vol ∝ ω ⇒ Std_TS = a + b·ω with high R² ⇒ Case 2.
+    names = [f"S{i}" for i in range(20)]
+    omega = pd.Series({n: 0.10 + 0.02 * i for i, n in enumerate(names)})
+    history = _signal_history({n: 2.0 * omega[n] for n in names})  # vol ∝ ω
+    res = refine.case_test(history, omega, price_derived=False)
+    assert res["case"] == 2
+    assert res["engaged"] and not res["ambiguous"]
+    assert res["r_squared"] >= 0.25 and res["t_stat"] >= 2.0
+
+
+def test_case_test_short_history_defaults_to_base_rate():
+    # Below min_obs the test can't decide → the empirical base rate, flagged ambiguous.
+    names = [f"S{i}" for i in range(20)]
+    omega = pd.Series({n: 0.15 for n in names})
+    history = _signal_history({n: 0.30 for n in names}, n_obs=10)  # too short
+    price = refine.case_test(history, omega, price_derived=True)
+    other = refine.case_test(history, omega, price_derived=False)
+    assert price["case"] == 2 and other["case"] == 1
+    assert not price["engaged"] and price["ambiguous"]
+
+
+# --------------------------------------------------------------------------- #
+# 2. c_g and the Case-2 scaling
+# --------------------------------------------------------------------------- #
+def test_case_scale_factor_is_vol_dimensioned_constant():
+    # c_g = Std_CS{g}/Std_CS{g/ω}. For g ∝ ω exactly, g/ω is constant ⇒ Std→0 ⇒ c_g→∞;
+    # for a realistic spread it lands between the min and max ω (a representative vol).
+    g = pd.Series({"A": 1.0, "B": 2.0, "C": 3.0, "D": 4.0, "E": 5.0})
+    omega = pd.Series({"A": 0.10, "B": 0.15, "C": 0.20, "D": 0.25, "E": 0.30})
+    c_g = refine.case_scale_factor(g, omega, winsorize_limits=(0.0, 1.0))
+    assert np.isfinite(c_g) and c_g > 0  # a finite, positive volatility-scale constant
+    assert 0.05 <= c_g <= 1.0
+
+
+def test_case2_replaces_per_name_vol_with_constant():
+    # Case 2 uses one c_g for every name; Case 1 uses each name's own ω. So the two
+    # alpha vectors are proportional only when ω is constant — here ω varies, so
+    # Case 2 removes the high-vol tilt Case 1 imposes.
+    raw = {f"S{i}": float(i - 6) for i in range(1, 13)}
+    vols = {s: 0.10 + 0.02 * i for i, s in enumerate(raw)}
+    p1 = FeaturePanel.for_universe(AS_OF, list(raw))
+    p1.set("score", raw)
+    p1.set("residual_vol", vols)
+    p2 = FeaturePanel.for_universe(AS_OF, list(raw))
+    p2.set("score", raw)
+    p2.set("residual_vol", vols)
+
+    refine_alpha(p1, AlphaContext(ic=0.05, scaling="case1"))
+    refine_alpha(p2, AlphaContext(ic=0.05, scaling="case2"))
+    a1, a2 = p1.get("alpha"), p2.get("alpha")
+    z = p1.get("z")
+    # Case 2 alpha is exactly IC·c_g·z (a constant scale on z).
+    c_g = refine.case_scale_factor(pd.Series(raw), pd.Series(vols))
+    for s in z.index:
+        assert abs(a2[s] - 0.05 * c_g * z[s]) < 1e-9
+    # And it is NOT the per-name Case-1 vector (the vol tilt is gone).
+    assert not np.allclose(a1.to_numpy(), a2.to_numpy())
+
+
+# --------------------------------------------------------------------------- #
+# 3. The IC-uncertainty level shrink
+# --------------------------------------------------------------------------- #
+def test_level_shrink_reproduces_reference_anchors():
+    # A good signal (IC 0.05, 5yr monthly) keeps ~13%; a great one (IC 0.10, 10yr) ~55%.
+    assert abs(refine.level_shrink_factor(0.05, 60) - 0.13) < 0.005
+    assert abs(refine.level_shrink_factor(0.10, 120) - 0.55) < 0.01
+
+
+def test_level_shrink_limits():
+    assert refine.level_shrink_factor(0.05, 1e12) > 0.999  # T→∞ ⇒ →1
+    assert refine.level_shrink_factor(1e-6, 60) < 1e-6  # IC→0 ⇒ →0
+    assert refine.level_shrink_factor(0.0, 60) == 0.0
+    assert refine.level_shrink_factor(0.05, 0) == 0.0  # no data ⇒ →0
+
+
+def test_overlap_honesty_teff_not_raw_t():
+    # Same panel at daily (n=252, horizon=21) vs monthly (n=12, horizon=1) sampling has
+    # the same *independent* observation count, so the same shrink factor. Raw T would
+    # differ by 21×.
+    t_daily = effective_sample_size(252, horizon=21, spacing=1.0)
+    t_monthly = effective_sample_size(12, horizon=1, spacing=1.0)
+    assert abs(t_daily - t_monthly) < 1e-9
+    ic = 0.06
+    assert abs(refine.level_shrink_factor(ic, t_daily) - refine.level_shrink_factor(ic, t_monthly)) < 1e-9
+    # Independent rebalances (spacing ≥ horizon) are not deflated.
+    assert effective_sample_size(12, horizon=5, spacing=21.0) == 12
+
+
+def test_level_shrink_applied_exactly_once_in_pipeline():
+    raw = {f"S{i}": float(i - 6) for i in range(1, 13)}
+    panel = FeaturePanel.for_universe(AS_OF, list(raw))
+    panel.set("score", raw)
+    panel.set("residual_vol", {s: 0.20 for s in raw})
+    refine_alpha(panel, AlphaContext(ic=0.05, level_shrink=(0.05, 60)))
+    chain = panel.meta["shrink_chain"]
+    ic_steps = [s for s in chain if s["step"] == "ic_uncertainty"]
+    assert len(ic_steps) == 1
+    assert abs(ic_steps[0]["multiplier"] - refine.level_shrink_factor(0.05, 60)) < 1e-12
+
+
+def test_no_level_shrink_when_off():
+    raw = {f"S{i}": float(i - 6) for i in range(1, 13)}
+    panel = FeaturePanel.for_universe(AS_OF, list(raw))
+    panel.set("score", raw)
+    panel.set("residual_vol", {s: 0.20 for s in raw})
+    refine_alpha(panel, AlphaContext(ic=0.05))  # level_shrink defaults None
+    chain = panel.meta["shrink_chain"]
+    assert [s for s in chain if s["step"] == "ic_uncertainty"] == []
+
+
+# --------------------------------------------------------------------------- #
+# 4. The equal-risk bucket diagnostic
+# --------------------------------------------------------------------------- #
+def _diag_book(n, vols, weights, seed=0):
+    """A diagonal-Σ diagnostic on a synthetic book (independent names)."""
+    symbols = [f"S{i}" for i in range(n)]
+    sigma = np.diag(np.asarray(vols) ** 2)
+    return risk_bucket_diagnostic(
+        pd.Series(weights, index=symbols),
+        sigma,
+        symbols,
+        pd.Series(vols, index=symbols),
+    )
+
+
+def test_correctly_scaled_book_passes():
+    # Correct scaling: active weight ∝ z/σ, so w·σ (contribution to vol) is ~constant ⇒
+    # variance contribution ~equal per name ⇒ no vol-bucket tilt.
+    rng = np.random.default_rng(1)
+    n = 60
+    vols = np.linspace(0.15, 0.60, n)
+    z = rng.normal(0, 1, n)
+    weights = z / vols  # w ∝ z/σ ⇒ w·σ = z (equal risk per name)
+    res = _diag_book(n, vols, weights)
+    assert res["engaged"] and not res["tilt_detected"]
+
+
+def test_case_misscaled_book_shows_monotone_tilt():
+    # A Case-2-signal scaled as Case 1 multiplies in σ a second time: w ∝ z·σ, so the
+    # per-name variance contribution ∝ σ⁴ — a strong monotone tilt into high-vol names.
+    rng = np.random.default_rng(2)
+    n = 60
+    vols = np.linspace(0.15, 0.60, n)
+    z = rng.normal(0, 1, n)
+    weights = z * vols  # the double-counted-vol book
+    res = _diag_book(n, vols, weights)
+    assert res["engaged"] and res["tilt_detected"]
+    assert res["variance_share_gradient"] > 0  # tilt toward the high-vol bucket
+    assert "high-vol" in res["verdict"]
+
+
+def test_bucket_diagnostic_degrades_and_suppresses_on_thin_universe():
+    thin = _diag_book(10, [0.2] * 10, [0.1] * 10)  # < terciles threshold
+    assert thin["engaged"] is False
+    tercile = _diag_book(18, list(np.linspace(0.1, 0.5, 18)), list(np.random.default_rng(3).normal(0, 1, 18)))
+    assert tercile["engaged"] and tercile["n_buckets"] == 3
+
+
+# --------------------------------------------------------------------------- #
+# 5. Service wiring + the Case-1 equivalence guard
+# --------------------------------------------------------------------------- #
+def _client(symbols, n=260):
+    data = {s: make_ohlcv(n=n, seed=i, freq="1D") for i, s in enumerate([*symbols, "SPY"])}
+    return MarketDataClient(DictMarketData(data)), data
+
+
+def test_compute_alphas_case1_default_is_unchanged_equivalence_guard():
+    # The default path must be byte-for-byte the base refinement pipeline (scaling defaults to
+    # case1, no level shrink): the refactor changes nothing it shouldn't.
+    symbols = [f"S{i:02d}" for i in range(12)]
+    client, data = _client(symbols)
+    as_of = data["S00"].index[-1].to_pydatetime()
+    res = analysis.compute_alphas(client, "ma_crossover", symbols, as_of, benchmark="SPY")
+    assert res["scaling"] == "case1"
+    assert res["case"] is None  # no case test run on the default path
+    # The scale step is Case 1, no ic_uncertainty step (assumed IC has none to shrink).
+    assert res["shrink_chain"][0]["case"] == 1
+    assert [s for s in res["shrink_chain"] if s["step"] == "ic_uncertainty"] == []
+
+
+def test_compute_alphas_auto_scaling_reports_case_diagnostics():
+    symbols = [f"S{i:02d}" for i in range(12)]
+    client, data = _client(symbols)
+    as_of = data["S00"].index[-1].to_pydatetime()
+    res = analysis.compute_alphas(client, "ma_crossover", symbols, as_of, benchmark="SPY", scaling="auto")
+    assert res["scaling"] in ("case1", "case2")
+    assert res["case"] is not None
+    assert "candidate_correlation" in res["case"]
+    assert res["scaling"] == f"case{res['case']['case']}"
+
+
+def test_compute_information_emits_shrink_chain_and_bucket_diagnostic():
+    symbols = [f"S{i:02d}" for i in range(30)]
+    client, data = _client(symbols, n=400)
+    start = data["S00"].index[40].to_pydatetime()
+    end = data["S00"].index[-1].to_pydatetime()
+    res = analysis.compute_information(client, "ma_crossover", symbols, start, end, benchmark="SPY")
+    assert "level_shrink_factor" in res and "effective_t" in res
+    chain = res["shrink_chain"]
+    assert len([s for s in chain if s["step"] == "ic_uncertainty"]) == 1
+    # 0 ≤ shrink factor ≤ 1, and consistent with the reported IC and T_eff.
+    assert 0.0 <= res["level_shrink_factor"] <= 1.0
+    expected = refine.level_shrink_factor(res["recommended_ic"], res["effective_t"])
+    assert abs(res["level_shrink_factor"] - expected) < 1e-9
+    # The bucket diagnostic engages on a 30-name universe (terciles) and returns a verdict.
+    assert res["risk_bucket_diagnostic"] is not None
+    assert res["risk_bucket_diagnostic"]["engaged"] in (True, False)
+
+
+def test_combined_path_owns_level_shrink_and_does_not_double_apply():
+    symbols = [f"S{i:02d}" for i in range(10)]
+    client, data = _client(symbols, n=400)
+    as_of = data["S00"].index[-1].to_pydatetime()
+    res = analysis.compute_combined_alphas(
+        client, ["ma_crossover", "mean_reversion"], symbols, as_of, benchmark="SPY", horizon=5, n_points=10
+    )
+    chain = res["shrink_chain"]
+    ic_steps = [s for s in chain if s["step"] == "ic_uncertainty"]
+    assert len(ic_steps) == 1  # exactly one "is the IC real" step (013 owns it here)
+    assert ic_steps[0]["owner"] == "combination_shrink"
+
+
+def test_run_scaling_ab_compares_both_scalings():
+    symbols = [f"S{i:02d}" for i in range(15)]
+    client, data = _client(symbols, n=400)
+    start = data["S00"].index[40].to_pydatetime()
+    end = data["S00"].index[-1].to_pydatetime()
+    res = analysis.run_scaling_ab(client, "ma_crossover", symbols, start, end, benchmark="SPY", n_points=12)
+    assert "case1_realized_ir" in res and "case2_realized_ir" in res
+    assert res["regression_pick"] in ("case1", "case2")
+    assert res["ab_pick"] in ("case1", "case2")
+    assert isinstance(res["agree"], bool)

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -1,4 +1,4 @@
-"""Tests for information horizon / alpha decay (spec 012)."""
+"""Tests for information horizon / alpha decay."""
 
 from datetime import datetime
 

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -1,4 +1,4 @@
-"""Tests for information analysis (spec 009): IC, breadth, IR reconciliation."""
+"""Tests for information analysis: IC, breadth, IR reconciliation."""
 
 from datetime import datetime
 
@@ -91,7 +91,7 @@ def test_compute_information_zero_skill_null():
     assert abs(r["multiple_testing_inflation"] - (1 - 0.95**10)) < 1e-9
 
 
-# --- attribution (009 §3.4) --------------------------------------------------
+# --- attribution -------------------------------------------------------------
 def test_factor_split_closes():
     from src.services.analysis import _factor_split
 

--- a/tests/test_portfolio_optimizer.py
+++ b/tests/test_portfolio_optimizer.py
@@ -1,4 +1,4 @@
-"""Tests for mean-variance portfolio construction (spec 008).
+"""Tests for mean-variance portfolio construction.
 
 Offline and deterministic. Covers the closed-form optimum, target-TE calibration,
 transfer-coefficient monotonicity, the no-trade band, turnover-from-w0,

--- a/tests/test_risk_streaming.py
+++ b/tests/test_risk_streaming.py
@@ -1,4 +1,4 @@
-"""Tests for the out-of-core streaming sample covariance (spec 015 follow-on).
+"""Tests for the out-of-core streaming sample covariance.
 
 Proves the streaming estimator reproduces the eager ``build_risk_matrix`` oracle
 (to machine epsilon) and that it runs in memory bounded by chunk size, not history.

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,4 +1,4 @@
-"""Tests for the out-of-core Parquet bar store (spec 011).
+"""Tests for the out-of-core Parquet bar store.
 
 Skipped automatically if the optional ``store`` extra (pyarrow) isn't installed.
 """
@@ -131,7 +131,7 @@ def test_streaming_backtest_matches_batch(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# Date-partitioned layout (symbol=…/year=…) and file-level date pruning (spec 015)
+# Date-partitioned layout (symbol=…/year=…) and file-level date pruning
 # --------------------------------------------------------------------------- #
 def test_write_creates_year_partitions(tmp_path):
     store = ParquetBarStore(tmp_path)

--- a/website/docs/engineering/alphas.md
+++ b/website/docs/engineering/alphas.md
@@ -114,6 +114,73 @@ rules that keep degraded inputs honest rather than silently wrong:
   mean-imputed per rule 2).
 :::
 
+## Forecast refinement v2
+
+The identity `α = σ·IC·z` is exactly right — *when* the cross-sectional z we compute
+equals the **time-series** z the standard rule is stated in. Whether it does is an
+empirical property of each signal, and two refinements the base pipeline skipped close
+the gap.
+
+### The Case test — which scaling is right
+
+- **Case 1** — a signal's per-name time-series vol `Std_TS{g_n}` is ~constant across
+  names ⇒ `z_TS ≈ z_CS` and the `σ_n` multiply is correct (the classic sector-momentum
+  example). This is `α = σ·IC·z`, unchanged.
+- **Case 2** — `Std_TS{g_n}` is ~proportional to the name's residual vol `σ_n`
+  (empirically, **most** price/estimate signals — momentum, reversal, revision) ⇒ the
+  vol is already inside the raw signal, and multiplying by `σ_n` **double-counts** it,
+  systematically overweighting high-vol names. The fix replaces the per-name `σ_n`
+  with one cross-sectional constant `c_g = Std_CS{g} / Std_CS{g/σ}`:
+
+  ```
+  α_n = IC · c_g · z_n          # Case 2 — one constant scale, no per-name vol tilt
+  ```
+
+`refine.case_test(signal_history, σ)` decides by regressing `Std_TS{g_n} = a + b·σ_n`
+across names: **R² ≥ 0.25 and a significant slope ⇒ Case 2; R² ≤ 0.05 ⇒ Case 1**; the
+ambiguous band defaults to the base rate (**Case 2 for price-derived signals, Case 1
+otherwise**), flagged `ambiguous` so a wrong call is visible. `c_g` is computed on the
+**raw** signal, winsorized exactly as the pipeline winsorizes — after standardization
+the raw dispersion that defines it is gone. `--scaling case1|case2|auto` selects it;
+`--scaling-ab` (on the `info` command) is the ground-truth tiebreak: it walk-forwards
+the realized IR under both scalings.
+
+### The IC-uncertainty level shrink
+
+The IC that scales alphas is itself **estimated**, and its sampling error dominates
+the mapping (`Var{Δβ/β} ≈ 1/(IC²·T)`). The Bayes-with-zero-prior fix is one factor on
+the whole level:
+
+```
+α ← α · 1/(1 + 1/(T_eff·IC²))      # = g/(g+1),  g = T_eff·IC²
+```
+
+The honest magnitudes are startling: a *good* signal (IC 0.05) with 5 years of monthly
+data keeps **13%** of its naive alpha; a great one (IC 0.10, 10 years) keeps ~55%.
+Two subtleties the implementation gets right:
+
+- **`T_eff`, not raw T.** Daily rows with a 21-day horizon are ~21× overlapped; using
+  the raw count under-shrinks by that factor.
+  [`horizon.effective_sample_size`](./information-horizon.md) deflates by the
+  horizon/spacing overlap, so the same panel sampled daily-with-a-monthly-horizon and
+  monthly gives the *same* shrink.
+- **No double-shrink.** The combination's per-signal Bayesian shrink and this level
+  shrink are the same `g/(g+1)` math. The rule: **the level shrink owns "is the IC
+  real"; the combination owns "how correlated signals share credit."** So it is applied
+  **exactly once** — by the level shrink on the single-signal measured path, and by the
+  combination's per-signal shrink on the combined path (never both). Every result
+  echoes a `shrink_chain` with one multiplier per step so the total haircut is auditable.
+
+### The equal-risk-contribution diagnostic
+
+A production monitor that catches a mis-scaled alpha *after the fact*: under correct
+scaling every residual-vol bucket contributes ~equally to active variance (`E{z²}=1`),
+so a bucket's share of `w_aᵀΣw_a` should track its share of *names*, not its vol. The
+`info` report buckets the paper active book by residual-vol quantile and flags a
+**monotone gradient** as the fingerprint of mis-scaling (usually a Case mis-choice). It
+degrades quintiles → terciles → suppressed as the universe thins, because a bucket mean
+of `z²` has sampling error `√(2/n)` — quintiles on 30 names are noise, not signal.
+
 ## The feature panel and refinement
 
 The refinement runs over a [`FeaturePanel`](./data-panel.md) — the cross-sectional,

--- a/website/docs/engineering/information-analysis.md
+++ b/website/docs/engineering/information-analysis.md
@@ -86,6 +86,17 @@ place, two more diagnostics close the loop:
   `capacity_capital` — the size at which net active return crosses zero — by bisection
   over the proposed portfolio's impact cost.
 
+Two more ride the same report:
+
+- **IC-uncertainty level shrink.** The measured IC is itself estimated; the report
+  echoes `level_shrink_factor` = `g/(g+1)` with `g = T_eff·IC²` — the fraction of the
+  naive alpha *level* that survives that estimation error — plus the shrunk IC to
+  deploy. `T_eff` deflates the rebalance count for horizon overlap. See the
+  [forecast-refinement-v2 section](./alphas#forecast-refinement-v2).
+- **Equal-risk-contribution monitor.** `risk_bucket_diagnostic` buckets the
+  paper active book by residual vol and flags a monotone variance-share gradient — the
+  fingerprint of a mis-scaled (wrong-Case) alpha.
+
 ## Where it runs
 
 `services.compute_information` scans the window, samples rebalances, measures the IC

--- a/website/docs/engineering/multi-signal.md
+++ b/website/docs/engineering/multi-signal.md
@@ -59,9 +59,19 @@ the mean cross-sectional correlation between signals is `Ω`. Measuring on
 out-of-sample data is what keeps the combination from over-fitting its own weights.
 
 The combined score then flows through the **same** [`refine_alpha`](./alphas)
-pipeline, scaled by the combined IC. So Spec 005's single assumed IC scalar is
-*replaced* by one measured, shrunk, redundancy-aware number — applied once, never
+pipeline, scaled by the combined IC. So the [single-signal](./alphas) assumed IC scalar
+is *replaced* by one measured, shrunk, redundancy-aware number — applied once, never
 twice.
+
+:::note Who owns the level shrink
+The per-signal Bayesian shrink here and the
+[IC-uncertainty level shrink](./alphas#forecast-refinement-v2) are the *same* `g/(g+1)`
+math, so applying both would double-shrink and undertrade forever. The rule: **the
+level shrink owns "is the IC real"; the combination owns "how correlated signals share
+credit."** On this combined path the combination discharges the level; the level shrink
+is *not* re-applied. The result echoes a `shrink_chain` so the single application is
+auditable.
+:::
 
 ## Where it runs
 

--- a/website/docs/engineering/portfolio-construction.md
+++ b/website/docs/engineering/portfolio-construction.md
@@ -16,8 +16,8 @@ maximize   U(w) = αᵀw − λ_A · wᵀΣw          (long-only absolute: bench
 subject to Σw = 1,  0 ≤ w ≤ max_weight,  ‖w‖₀ ≤ max_names
 ```
 
-α is the [alpha](./alphas) vector (Spec 005), Σ the [covariance](./risk-model)
-(Spec 006), and `λ_A` the aversion to active variance.
+α is the [alpha](./alphas) vector, Σ the [covariance](./risk-model), and `λ_A` the
+aversion to active variance.
 
 :::note Research clock — a proposal, not an order
 This is portfolio *construction*: it proposes target weights (a config a human

--- a/website/docs/usage/alphas.md
+++ b/website/docs/usage/alphas.md
@@ -47,6 +47,28 @@ residual return for the year. The ranking is what a mean-variance
 | `--neutralize` | off | Make alphas beta-neutral (regress out benchmark beta). |
 | `--neutralize-factors` | off | Make alphas **factor-neutral**: regress out the risk model's exposures. Bare flag = `market,volatility,size` (momentum kept — a momentum tilt is a return bet the alpha may intend); or pass a comma-separated subset. |
 | `--lookback-days` | `180` | History fetched (≤ `as_of`) for the residual-vol estimate. |
+| `--scaling` | `case1` | Per-name scaling: `case1` = `σ·IC·z`; `case2` = `IC·c_g·z` (no per-name vol multiply); `auto` = let a `Std_TS`-vs-`σ` regression decide, echoing the Case test. |
+
+## Case scaling
+
+`α = σ·IC·z` multiplies each name's score by its residual vol. That is right only if
+the signal's per-name vol is *constant* across names (**Case 1**). For most
+price-derived signals the vol is already *inside* the signal (**Case 2**), and the
+`σ` multiply double-counts it — tilting the book into high-vol names.
+`--scaling auto` runs a regression to decide and prints the verdict:
+
+```bash
+python main.py alphas --strategy mean_reversion --symbols ... --as-of 2025-06-01 --scaling auto
+```
+
+```
+  scaling: case2 — Case 2 (R²=0.41, t=+3.8, candidate corr 0.62)
+```
+
+`candidate corr` is how different the two scalings actually are here (near 1 ⇒ the
+choice barely matters). The ground-truth tiebreak is `info --scaling-ab`, which
+walk-forwards the realized IR under both. See
+[Continuous alphas](../engineering/alphas.md#forecast-refinement-v2).
 
 Use `--source scanner` to rank by a scanner's continuous conviction instead of the
 strategy's score:

--- a/website/docs/usage/information.md
+++ b/website/docs/usage/information.md
@@ -47,6 +47,21 @@ how inflated a "significant" result is once you account for everything you tried
 | `--horizon` | `5` | Forward-return horizon, in bars. |
 | `--n-trials` | `1` | Configs tried, for the multiple-testing inflation. |
 | `--neutralize-factors` | off | Measure the **factor-neutral** alpha (bare flag = `market,volatility,size`) — use the same setting you deploy with, so the measured IC/IR describes the forecast you actually trade. Also on `horizon`. |
+| `--scaling-ab` | off | Research mode: walk-forward the realized IR under **Case-1** (`σ·IC·z`) vs **Case-2** (`IC·c_g·z`) scaling and compare against the regression's pick — the ground-truth tiebreak for the [Case test](alphas#case-scaling). |
+
+## The level shrink and the risk-bucket monitor
+
+The report also carries two more diagnostics:
+
+- **Level shrink.** The measured IC is itself estimated; the report prints
+  what fraction of the naive level survives that estimation error —
+  `keep 13% of the naive level (T_eff 60, IC 0.05)` — and the shrunk IC to deploy.
+  `T_eff` deflates the rebalance count for horizon overlap, so a daily-sampled monthly
+  horizon isn't credited 21× the observations it really has.
+- **Risk buckets.** Under correct scaling every residual-vol bucket
+  contributes ~equally to active variance; a **monotone gradient** flags a mis-scaled
+  alpha (usually a Case mis-choice). Suppressed on universes too thin for reliable
+  buckets rather than reporting noise.
 
 ## What it does (and doesn't) tell you
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -14,12 +14,18 @@ const config = {
   url: 'https://tradeflow.mk-dir.com',
   baseUrl: '/',
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  // Broken internal links and anchors fail the build — the docs CI relies on this
+  // to catch dead cross-references (e.g. a renamed heading) before they ship.
+  onBrokenLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   // Render ```mermaid fenced code blocks as diagrams.
   markdown: {
     mermaid: true,
+    // (was the deprecated top-level `onBrokenMarkdownLinks`.)
+    hooks: {
+      onBrokenMarkdownLinks: 'throw',
+    },
   },
   themes: ['@docusaurus/theme-mermaid'],
 


### PR DESCRIPTION
## What

Three refinements to the alpha-forecast pipeline, so alphas are scaled correctly *per name* and at the right overall *level*, plus a production monitor that catches mis-scaling after the fact.

### 1. Per-name Case scaling
The identity `α = σ·IC·z` is stated in time-series z-scores; the pipeline computes cross-sectional z. Whether they coincide is a per-signal empirical property:
- **Case 1** — per-name signal vol constant across names → `σ·IC·z` is right (unchanged default).
- **Case 2** — signal vol ∝ the name's residual vol (most price signals) → the vol is already in the signal, and the `σ` multiply double-counts it. Scale by one constant `c_g = Std_CS{g}/Std_CS{g/σ}` instead.

`case_test()` decides by regressing `Std_TS{g_n}` on `σ_n` (R²≥0.25 & significant → Case 2; R²≤0.05 → Case 1; ambiguous → base rate, flagged). `--scaling case1|case2|auto`; `info --scaling-ab` walk-forwards the realized IR under both as the ground-truth tiebreak.

### 2. IC-uncertainty level shrink
The measured IC is itself estimated. `α ← α · g/(g+1)`, `g = T_eff·IC²` shrinks the *level* for that estimation error (a good signal keeps ~13% of its naive alpha; a great one ~55%). `T_eff` deflates the rebalance count for horizon overlap, so overlapping horizons don't inflate the observation count.

**No double-shrink:** the level shrink owns "is the IC real"; the multi-signal combination owns "how correlated signals share credit." Applied exactly once per path — by the level shrink on the single-signal path, by the combination's per-signal Bayesian shrink on the combined path — never both. Every result echoes an auditable `shrink_chain`.

### 3. Equal-risk-contribution monitor
Under correct scaling every residual-vol bucket contributes ~equally to active variance; a monotone variance-share gradient flags a mis-scaled book. Lands in the `info` report; degrades quintile→tercile→suppressed as the universe thins.

## Scope
- Core math: `src/alphas/refine.py`, `horizon.py`, `base.py` (defaults preserve the existing pipeline byte-for-byte — equivalence guard).
- Wiring: `information.py` (bucket diagnostic), `services/analysis.py` (`compute_alphas` scaling, `compute_information` shrink chain + bucket, `run_scaling_ab`), CLI (`main.py`), MCP (`compute_alphas --scaling`).
- The final commit is a repo-wide cleanup: code/docs now describe behavior directly instead of citing local (gitignored) specs or external sources, and `PROCESS.md §3` codifies the convention.

## Verification
- `make test`: **270 passed, 4 skipped** (18 new tests; `test_stream.py` needs the optional `alpaca` SDK, unrelated).
- `ruff check` / `ruff format --check`: clean.
- **Two clocks:** research-clock only — forecasts and diagnostics, no order-path changes; MCP surface stays data-only.

## Docs
Engineering: Continuous-alphas (new *Forecast refinement v2* section), Information-analysis, Multi-signal. Usage: Ranking-by-alpha (`--scaling`), Information (`--scaling-ab`, level-shrink + bucket lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)